### PR TITLE
Updated CODEOWNERS for new org name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,6 @@
 # Any changes to dependencies deserve extra scrutiny to help prevent supply
 # chain attacks
 package.json @greg-nagy @0xDaedalus @shadowfiend @mhluongo
-yarn.lock @tallycash/extension-dependency-auditors
+yarn.lock @tallyhowallet/extension-dependency-auditors
 # Any changes to code owners deserve extra scrutiny
 .github/CODEOWNERS @shadowfiend @mhluongo


### PR DESCRIPTION
tallycash has become tallyhowallet, so the old team name did not resolve.

Latest build: [extension-builds-2792](https://github.com/tallyhowallet/extension/suites/9896250759/artifacts/478063092) (as of Thu, 15 Dec 2022 21:09:12 GMT).