### PR TITLE
Add test for price point asset selector

### DIFF
--- a/background/assets.ts
+++ b/background/assets.ts
@@ -184,9 +184,9 @@ export function isFungibleAsset(asset: AnyAsset): asset is FungibleAsset {
 /**
  * Type guard to check if an AnyAsset is actually a SmartContractFungibleAsset.
  */
-export function isSmartContractFungibleAsset(
-  asset: AnyAsset
-): asset is SmartContractFungibleAsset {
+export function isSmartContractFungibleAsset<T extends AnyAsset>(
+  asset: T
+): asset is T & SmartContractFungibleAsset {
   return "homeNetwork" in asset && isFungibleAsset(asset)
 }
 

--- a/background/redux-slices/assets.test.ts
+++ b/background/redux-slices/assets.test.ts
@@ -1,0 +1,90 @@
+import { PricePoint, SmartContractFungibleAsset } from "../assets"
+import { ETHEREUM, POLYGON } from "../constants"
+import { AssetsState, selectAssetPricePoint, SingleAssetState } from "./assets"
+
+const asset: SmartContractFungibleAsset = {
+  metadata: {
+    logoURL:
+      "https://messari.io/asset-images/0783ede3-4b2c-418a-9f82-f171894c70e2/128.png",
+    tokenLists: [
+      {
+        url: "https://gateway.ipfs.io/ipns/tokens.uniswap.org",
+        name: "Uniswap Labs Default",
+        logoURL: "ipfs://QmNa8mQkrNKp1WEEeGjFezDmDeodkWRevGFN8JCV7b4Xir",
+      },
+    ],
+  },
+  name: "Keep Network",
+  symbol: "KEEP",
+  decimals: 18,
+  homeNetwork: ETHEREUM,
+  contractAddress: "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
+}
+
+const pricePoint: PricePoint = {
+  pair: [
+    asset,
+    {
+      name: "United States Dollar",
+      symbol: "USD",
+      decimals: 10,
+    },
+  ],
+  amounts: [1000000000000000000n, 873910000n],
+  time: 1671166100,
+}
+
+const assetWithPricePoint = {
+  ...asset,
+  recentPrices: {
+    USD: pricePoint,
+  },
+}
+
+const assetState: AssetsState = [assetWithPricePoint]
+
+describe("Assets selectors", () => {
+  describe("Price Points", () => {
+    test("should retrieve price point for an asset", () => {
+      const result = selectAssetPricePoint(assetState, asset, "USD")
+
+      expect(result).toMatchObject(pricePoint)
+    })
+
+    /* Best effort matches */
+    test("should fallback to a price point for an asset with the same symbol", () => {
+      /* same symbol, different network */
+      const assetWithoutPricePoint: SingleAssetState = {
+        ...asset,
+        homeNetwork: POLYGON,
+        recentPrices: {},
+      }
+
+      const state = [...assetState, assetWithoutPricePoint]
+      const result = selectAssetPricePoint(state, assetWithoutPricePoint, "USD")
+
+      expect(result).toMatchObject(pricePoint)
+    })
+
+    test("should match queried asset decimals when falling back to a best effort match", () => {
+      /* same symbol, different network, different decimals */
+      const assetWithoutPricePoint: SingleAssetState = {
+        ...asset,
+        homeNetwork: POLYGON,
+        decimals: 6,
+        recentPrices: {},
+      }
+
+      const state = [assetWithPricePoint, assetWithoutPricePoint]
+      const result = selectAssetPricePoint(state, assetWithoutPricePoint, "USD")
+
+      expect(assetWithPricePoint.decimals).toBe(18)
+
+      expect(result).toMatchObject({
+        ...pricePoint,
+        // 6 decimals
+        amounts: [1_000_000n, pricePoint.amounts[1]],
+      })
+    })
+  })
+})

--- a/background/redux-slices/assets.test.ts
+++ b/background/redux-slices/assets.test.ts
@@ -1,38 +1,11 @@
 import { PricePoint, SmartContractFungibleAsset } from "../assets"
-import { ETHEREUM, POLYGON } from "../constants"
+import { POLYGON } from "../constants"
+import { createPricePoint, createSmartContractAsset } from "../tests/factories"
 import { AssetsState, selectAssetPricePoint, SingleAssetState } from "./assets"
 
-const asset: SmartContractFungibleAsset = {
-  metadata: {
-    logoURL:
-      "https://messari.io/asset-images/0783ede3-4b2c-418a-9f82-f171894c70e2/128.png",
-    tokenLists: [
-      {
-        url: "https://gateway.ipfs.io/ipns/tokens.uniswap.org",
-        name: "Uniswap Labs Default",
-        logoURL: "ipfs://QmNa8mQkrNKp1WEEeGjFezDmDeodkWRevGFN8JCV7b4Xir",
-      },
-    ],
-  },
-  name: "Keep Network",
-  symbol: "KEEP",
-  decimals: 18,
-  homeNetwork: ETHEREUM,
-  contractAddress: "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
-}
+const asset: SmartContractFungibleAsset = createSmartContractAsset()
 
-const pricePoint: PricePoint = {
-  pair: [
-    asset,
-    {
-      name: "United States Dollar",
-      symbol: "USD",
-      decimals: 10,
-    },
-  ],
-  amounts: [1000000000000000000n, 873910000n],
-  time: 1671166100,
-}
+const pricePoint: PricePoint = createPricePoint(asset)
 
 const assetWithPricePoint = {
   ...asset,
@@ -51,25 +24,14 @@ describe("Assets selectors", () => {
       expect(result).toMatchObject(pricePoint)
     })
 
-    test("should retrieve exact price point for a smart contract asset if available", () => {
+    test("should retrieve the correct price point for an asset that shares a symbol with other assets across networks", () => {
       /* same symbol, network, different contract address */
       const similarAsset = {
         ...asset,
         contractAddress: "0xf4d2888d29d722226fafa5d9b24f9164c092421e",
       }
 
-      const similarAssetPricePoint: PricePoint = {
-        pair: [
-          similarAsset,
-          {
-            name: "United States Dollar",
-            symbol: "USD",
-            decimals: 10,
-          },
-        ],
-        amounts: [1000000000000000000n, 123450000n],
-        time: 1671166100,
-      }
+      const similarAssetPricePoint: PricePoint = createPricePoint(similarAsset)
 
       const similarAssetWithPricePoint: SingleAssetState = {
         ...similarAsset,
@@ -85,7 +47,7 @@ describe("Assets selectors", () => {
     })
 
     /* Best-effort matches */
-    test("should fallback to a price point for an asset with the same symbol", () => {
+    test("If a network-specific price point is unavailable, should fallback to a price point for an asset with the same symbol", () => {
       /* same symbol, different network */
       const assetWithoutPricePoint: SingleAssetState = {
         ...asset,

--- a/background/redux-slices/assets.test.ts
+++ b/background/redux-slices/assets.test.ts
@@ -51,7 +51,40 @@ describe("Assets selectors", () => {
       expect(result).toMatchObject(pricePoint)
     })
 
-    /* Best effort matches */
+    test("should retrieve exact price point for a smart contract asset if available", () => {
+      /* same symbol, network, different contract address */
+      const similarAsset = {
+        ...asset,
+        contractAddress: "0xf4d2888d29d722226fafa5d9b24f9164c092421e",
+      }
+
+      const similarAssetPricePoint: PricePoint = {
+        pair: [
+          similarAsset,
+          {
+            name: "United States Dollar",
+            symbol: "USD",
+            decimals: 10,
+          },
+        ],
+        amounts: [1000000000000000000n, 123450000n],
+        time: 1671166100,
+      }
+
+      const similarAssetWithPricePoint: SingleAssetState = {
+        ...similarAsset,
+        recentPrices: {
+          USD: similarAssetPricePoint,
+        },
+      }
+
+      const state = [assetWithPricePoint, similarAssetWithPricePoint]
+      const result = selectAssetPricePoint(state, similarAsset, "USD")
+
+      expect(result).toMatchObject(similarAssetPricePoint)
+    })
+
+    /* Best-effort matches */
     test("should fallback to a price point for an asset with the same symbol", () => {
       /* same symbol, different network */
       const assetWithoutPricePoint: SingleAssetState = {
@@ -60,7 +93,7 @@ describe("Assets selectors", () => {
         recentPrices: {},
       }
 
-      const state = [...assetState, assetWithoutPricePoint]
+      const state = [assetWithPricePoint, assetWithoutPricePoint]
       const result = selectAssetPricePoint(state, assetWithoutPricePoint, "USD")
 
       expect(result).toMatchObject(pricePoint)

--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -211,7 +211,6 @@ export const selectAssetPricePoint = createSelector(
       pricedAsset = assets.find(
         (asset): asset is AssetWithRecentPrices<SmartContractFungibleAsset> =>
           isSmartContractFungibleAsset(asset) &&
-          asset.symbol === assetToFind.symbol &&
           asset.contractAddress === assetToFind.contractAddress &&
           asset.homeNetwork.chainID === assetToFind.homeNetwork.chainID &&
           hasRecentPriceData(asset)

--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -186,7 +186,7 @@ export const transferAsset = createBackgroundAsyncThunk(
  * Selects a particular asset price point given the asset symbol and the paired
  * asset symbol used to price it.
  *
- * For example, calling `selectAssetPricePoint(state.assets, "ETH", "USD")`
+ * For example, calling `selectAssetPricePoint(state.assets, ETH, "USD")`
  * will return the ETH-USD price point, if it exists. Note that this selector
  * guarantees that the returned price point will have the pair in the specified
  * order, so even if the store price point has amounts in the order [USD, ETH],
@@ -200,9 +200,9 @@ export const selectAssetPricePoint = createSelector(
       (asset) =>
         asset.symbol === assetToFind.symbol &&
         pairedAssetSymbol in asset.recentPrices &&
-        asset.recentPrices[pairedAssetSymbol].pair
-          .map(({ symbol }) => symbol)
-          .includes(assetToFind.symbol)
+        asset.recentPrices[pairedAssetSymbol].pair.some(
+          ({ symbol }) => symbol === assetToFind.symbol
+        )
     )
 
     if (pricedAsset) {

--- a/background/tests/factories.ts
+++ b/background/tests/factories.ts
@@ -22,6 +22,7 @@ import {
   ETHEREUM,
   OPTIMISM,
   POLYGON,
+  USD,
 } from "../constants"
 import {
   AnyEVMTransaction,
@@ -368,14 +369,7 @@ export const createPricePoint = (
   const decimals = isFungibleAsset(asset) ? asset.decimals : 18
 
   const pricePoint: PricePoint = {
-    pair: [
-      asset,
-      {
-        name: "United States Dollar",
-        symbol: "USD",
-        decimals: 10,
-      },
-    ],
+    pair: [asset, USD],
     amounts: [10n ** BigInt(decimals), BigInt(Math.trunc(1e11 * price))],
     time: Math.trunc(Date.now() / 1e3),
   }


### PR DESCRIPTION
Improves price point accuracy for smart contract assets and tests fix introduced by #2711 

Closes #2748

Latest build: [extension-builds-2793](https://github.com/tallyhowallet/extension/suites/9949807493/artifacts/481892529) (as of Mon, 19 Dec 2022 15:26:17 GMT).