### PR TITLE
Fix the issue with switching networks on Alpaca Finance

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -166,6 +166,14 @@ export default class TallyWindowProvider extends EventEmitter {
       }
     }
 
+    /**
+     * Some dApps may have a problem with preserving a reference to a provider object.
+     * This is the result of incorrect assignment.
+     * In such a case, the object this is undefined
+     * which results in an error in the execution of the request.
+     * The request function should always have a provider object set.
+     */
+    this.request = this.request.bind(this)
     monitorForWalletConnectionPrompts()
     this.transport.addEventListener(internalListener)
     this.transport.addEventListener(this.internalBridgeListener.bind(this))


### PR DESCRIPTION
Closes #2786 

This PR fixes the issue with switching networks on Alpaca Finance.

### Steps to Recreate
- Select `Ethereum` in the in-wallet network dropdown selector
- Navigate to https://app.alpacafinance.org/
- Connect with Tally Ho
- Click `Switch Network` when the in-dapp popup comes up.


Latest build: [extension-builds-2794](https://github.com/tallyhowallet/extension/suites/9904009093/artifacts/478651832) (as of Fri, 16 Dec 2022 08:18:22 GMT).