### PR TITLE
Fix issue with swapping on Pancakeswap with Ledger

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1095,6 +1095,17 @@ export default class Main extends BaseService<never> {
     this.internalEthereumProviderService.emitter.on(
       "transactionSignatureRequest",
       async ({ payload, resolver, rejecter }) => {
+        /**
+         * There is a case in which the user changes the settings on the ledger after connection.
+         * For example, it sets disabled blind signing. Before the transaction signature request
+         * ledger should be connected again to refresh the state. Without reconnection,
+         * the user doesn't receive an error message on how to fix it.
+         */
+        const isArbitraryDataSigningEnabled =
+          await this.ledgerService.isArbitraryDataSigningEnabled()
+        if (!isArbitraryDataSigningEnabled) {
+          this.connectLedger()
+        }
         this.store.dispatch(
           clearTransactionState(TransactionConstructionStatus.Pending)
         )

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -575,4 +575,13 @@ export default class LedgerService extends BaseService<Events> {
 
     return signatureHex
   }
+
+  async isArbitraryDataSigningEnabled(): Promise<boolean> {
+    if (this.transport) {
+      const eth = new Eth(this.transport)
+      const appConfig = await eth.getAppConfiguration()
+      return appConfig.arbitraryDataEnabled !== 0
+    }
+    return false
+  }
 }

--- a/ui/components/Signing/Signer/SignerLedger/SignerLedgerFrame.tsx
+++ b/ui/components/Signing/Signer/SignerLedger/SignerLedgerFrame.tsx
@@ -133,7 +133,7 @@ export default function SignerLedgerFrame<T extends SignOperationType>({
             )}
           </footer>
           <SharedSlideUpMenu
-            isOpen={isSlideUpOpen}
+            isOpen={isSlideUpOpen && ledgerCannotSign}
             size="auto"
             close={() => setIsSlideUpOpen(false)}
           >


### PR DESCRIPTION
Closes #2767 

This PR allows a swap on Pancakeswap with Ledger when the user has changed the Ledger settings.

## Steps to Recreate
- go to [pancakeswap](https://pancakeswap.finance/swap) to make swap with Ledger account
- try to do a swap when bling signing is enabled on the settings
- disable blind signing on the settings
- try to do a swap again

Latest build: [extension-builds-2796](https://github.com/tallyhowallet/extension/suites/9909132501/artifacts/478991299) (as of Fri, 16 Dec 2022 13:29:41 GMT).