### PR TITLE
Load NFT images with higher resolution if available

### DIFF
--- a/ui/components/NFTS_update/NFTImage.tsx
+++ b/ui/components/NFTS_update/NFTImage.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames"
-import React, { ReactElement, useState } from "react"
+import React, { ReactElement, useEffect, useState } from "react"
+import noop from "../../utils/noop"
 
 const noPreviewLink = "./images/no_preview.svg"
 
@@ -8,6 +9,7 @@ export default function NFTImage({
   height,
   alt,
   src,
+  highResolutionSrc,
   fit = "cover",
   isBadge = false,
   isZoomed = false,
@@ -17,6 +19,7 @@ export default function NFTImage({
   height?: number
   alt: string
   src?: string
+  highResolutionSrc?: string
   fit?: string
   isBadge?: boolean
   isZoomed?: boolean
@@ -24,6 +27,22 @@ export default function NFTImage({
 }): ReactElement {
   const [isLoading, setIsLoading] = useState(true)
   const [imageUrl, setImageUrl] = useState(src || noPreviewLink)
+
+  useEffect(() => {
+    if (!highResolutionSrc) {
+      return noop
+    }
+
+    const img = new Image()
+    const handleSuccessfulLoad = () => setImageUrl(highResolutionSrc)
+
+    img.src = highResolutionSrc
+    img.addEventListener("load", handleSuccessfulLoad)
+
+    return () => {
+      img.removeEventListener("load", handleSuccessfulLoad)
+    }
+  }, [highResolutionSrc])
 
   return (
     <>

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -29,6 +29,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
   const { nft, collection } = props
   const {
     thumbnailURL,
+    previewURL,
     contract,
     name,
     network,
@@ -68,6 +69,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
         <div className="preview_image">
           <NFTImage
             src={thumbnailURL}
+            highResolutionSrc={previewURL}
             alt={name}
             width={384}
             isBadge={isBadge}


### PR DESCRIPTION
Resolves https://github.com/tallyhowallet/extension/issues/2790

### What

On the NFTs Preview slide-up we would like to show images with higher resolution than on the list because they are bigger and poor quality starts to become visible.
As we already have loaded the smaller image (for the list items) it can be displayed instantly while the higher resolution image has some load time.
Let's progressively display images with better resolution on the preview while showing smaller images first for seamless UX.

### Testing

- load some accounts with NFTs, scroll the list, check out the preview slide-ups - images should be updated to higher resolution (barely visible most of the times I've checked)

Latest build: [extension-builds-2799](https://github.com/tallyhowallet/extension/suites/9986920660/artifacts/484584991) (as of Wed, 21 Dec 2022 09:15:58 GMT).