### PR TITLE
Nft filters improvements

### DIFF
--- a/background/redux-slices/nfts_update.ts
+++ b/background/redux-slices/nfts_update.ts
@@ -129,9 +129,9 @@ function updateFilter(
       ...filter,
     }
     if (type === "collections") {
-      if (acc.filters[type][existingFilterId].owners) {
-        const { owners = [] } = acc.filters[type][existingFilterId]
-        acc.filters[type][existingFilterId].owners = owners.concat([owner])
+      const owners = acc.filters[type][existingFilterId].owners ?? []
+      if (!owners.includes(owner)) {
+        acc.filters[type][existingFilterId].owners = [...owners, owner]
       }
     }
   } else {

--- a/background/redux-slices/nfts_update.ts
+++ b/background/redux-slices/nfts_update.ts
@@ -144,7 +144,10 @@ function updateFilter(
 }
 
 function updateFilters(acc: NFTsSliceState, collection: NFTCollection): void {
-  FILTER_TYPE.forEach((type) => updateFilter(acc, collection, type))
+  const { nftCount } = collection
+  if ((nftCount ?? 0) > 0) {
+    FILTER_TYPE.forEach((type) => updateFilter(acc, collection, type))
+  }
 }
 
 function initializeCollections(collections: NFTCollection[]): NFTsSliceState {

--- a/background/redux-slices/nfts_update.ts
+++ b/background/redux-slices/nfts_update.ts
@@ -101,13 +101,10 @@ function updateCollection(
   }
 }
 
-const FILTER_TYPE = ["accounts", "collections"] as const
-type FilterType = typeof FILTER_TYPE[number]
-
 function updateFilter(
   acc: NFTsSliceState,
   collection: NFTCollection,
-  type: FilterType
+  type: "accounts" | "collections"
 ): void {
   const { id, name, thumbnailURL, owner } = collection
 
@@ -146,8 +143,9 @@ function updateFilter(
 function updateFilters(acc: NFTsSliceState, collection: NFTCollection): void {
   const { nftCount } = collection
   if ((nftCount ?? 0) > 0) {
-    FILTER_TYPE.forEach((type) => updateFilter(acc, collection, type))
+    updateFilter(acc, collection, "collections")
   }
+  updateFilter(acc, collection, "accounts")
 }
 
 function initializeCollections(collections: NFTCollection[]): NFTsSliceState {

--- a/ui/components/NFTS_update/NFTsHeader.tsx
+++ b/ui/components/NFTS_update/NFTsHeader.tsx
@@ -64,6 +64,7 @@ export default function NFTsHeader(): ReactElement {
                 color="var(--green-40)"
                 hoverColor="var(--green-20)"
                 onClick={handleToggleClick}
+                disabled={isLoading}
               />
             </div>
           )}


### PR DESCRIPTION
This PR includes improvements for NFT filters.
Changes
- NFT filters are available after reloading on the main page
- Making sure that owners of NFTs from the same collection are correctly added to the array
- Don't add collections to filters when the number of NFT per collection is 0

##  UI
<img width="240" alt="Screenshot 2022-12-27 at 16 19 05" src="https://user-images.githubusercontent.com/23117945/209686659-64a08ee6-94fc-407f-a305-37bfc7a3b222.png">

<img width="240" alt="Screenshot 2022-12-27 at 16 20 00" src="https://user-images.githubusercontent.com/23117945/209686754-ee3dd5c6-4295-41c8-9f9a-5437d7e53d31.png">

## To Test
- [x] check if nft fillter button is disabled when nfts are reloading
- [x] check if accounts that don't have a collection are displayed in the filters
- [x] check if the collection filter works correctly when two different accounts have nft from the same collection. Turn off one account and check that the collection filter is still on the filter list. Test data:
  Collection name: ,,ENS: Ethereum Name Service"
  Accounts: `berrry.eth` and `pelagic.eth` 

## Testing Env

```
SUPPORT_NFT_TAB=true
```

Latest build: [extension-builds-2817](https://github.com/tallyhowallet/extension/suites/10152263754/artifacts/496037280) (as of Tue, 03 Jan 2023 07:35:19 GMT).