### PR TITLE
Add correct link to BSC/AVAX scan for NFT

### DIFF
--- a/background/lib/nfts.ts
+++ b/background/lib/nfts.ts
@@ -72,6 +72,7 @@ const SIMPLE_HASH_CHAIN_TO_ID = {
   polygon: 137,
   arbitrum: 42161,
   bsc: 56,
+  avalanche: 43114,
 }
 
 function simpleHashNFTModelToNFT(original: SimpleHashNFTModel): NFT {

--- a/ui/components/NFTs/NFTsSlideUpPreviewContent.tsx
+++ b/ui/components/NFTs/NFTsSlideUpPreviewContent.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from "react"
 import {
   ARBITRUM_ONE,
+  BINANCE_SMART_CHAIN,
   ETHEREUM,
   OPTIMISM,
   POLYGON,
@@ -27,6 +28,7 @@ function getPreviewLink(nft: NFT) {
     [ETHEREUM.chainID]: `/nft/${contractAddress}/${parsedTokenID}`,
     [OPTIMISM.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
     [ARBITRUM_ONE.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
+    [BINANCE_SMART_CHAIN.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
   }
 
   return `${scanWebsite[chainID].url}${previewURL[chainID]}`

--- a/ui/components/NFTs/NFTsSlideUpPreviewContent.tsx
+++ b/ui/components/NFTs/NFTsSlideUpPreviewContent.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from "react"
 import {
   ARBITRUM_ONE,
+  AVALANCHE,
   BINANCE_SMART_CHAIN,
   ETHEREUM,
   OPTIMISM,
@@ -29,6 +30,7 @@ function getPreviewLink(nft: NFT) {
     [OPTIMISM.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
     [ARBITRUM_ONE.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
     [BINANCE_SMART_CHAIN.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
+    [AVALANCHE.chainID]: `/token/${contractAddress}?a=${parsedTokenID}`,
   }
 
   return `${scanWebsite[chainID].url}${previewURL[chainID]}`


### PR DESCRIPTION
Closes #2765 

This PR adds the correct link to the BSC scan on the NFT page

Link: https://bscscan.com/token/0xE5b184875dd4f09f687d497d76c22D20Aec67788?a=7074

![Screenshot 2022-12-30 at 12 37 45](https://user-images.githubusercontent.com/23117945/210066317-4c4068e1-3453-4d34-bf69-3aef3c436f6f.png)

## To Test
- select BSC/AVAX network
- go to the NFTs tab
- open NFT slide up preview content
- open the NFT asset on BSC/AVAX scan

Latest build: [extension-builds-2823](https://github.com/tallyhowallet/extension/suites/10111955978/artifacts/493245761) (as of Fri, 30 Dec 2022 12:00:32 GMT).