### PR TITLE
Add scroll for swap quote view

### DIFF
--- a/ui/components/Swap/SwapQuote.tsx
+++ b/ui/components/Swap/SwapQuote.tsx
@@ -73,52 +73,62 @@ export default function SwapQuote({
   return (
     <section className="center_horizontal standard_width">
       <SharedActivityHeader label={t("title")} activity="swap" />
-      <div className="quote_cards">
-        <SwapQuoteAssetCard
-          label={t("sellAsset")}
-          asset={sellAsset}
-          amount={sellAmount}
-        />
-        <span className="icon_switch" />
-        <SwapQuoteAssetCard
-          label={t("buyAsset")}
-          asset={buyAsset}
-          amount={buyAmount}
-        />
-      </div>
-      <span className="label label_right">
-        1 {sellAsset.symbol} = {finalQuote.price} {buyAsset.symbol}
-      </span>
-      <div className="settings_wrap">
-        <SwapTransactionSettingsChooser
-          isSettingsLocked
-          swapTransactionSettings={swapTransactionSettings}
-        />
-      </div>
-      <div className="exchange_section_wrap">
-        <span className="top_label label">{t("exchangeRoute")}</span>
+      <div className="content_wrap">
+        <div className="quote_cards">
+          <SwapQuoteAssetCard
+            label={t("sellAsset")}
+            asset={sellAsset}
+            amount={sellAmount}
+          />
+          <span className="icon_switch" />
+          <SwapQuoteAssetCard
+            label={t("buyAsset")}
+            asset={buyAsset}
+            amount={buyAmount}
+          />
+        </div>
+        <span className="label label_right">
+          1 {sellAsset.symbol} = {finalQuote.price} {buyAsset.symbol}
+        </span>
+        <div className="settings_wrap">
+          <SwapTransactionSettingsChooser
+            isSettingsLocked
+            swapTransactionSettings={swapTransactionSettings}
+          />
+        </div>
+        <div className="exchange_section_wrap">
+          <span className="top_label label">{t("exchangeRoute")}</span>
 
-        {sources.map((source) => (
-          <div className="exchange_content standard_width" key={source.name}>
-            <div className="left">
-              {source.name.includes("Uniswap") && (
-                <span className="icon_uniswap" />
-              )}
-              {source.name}
+          {sources.map((source) => (
+            <div className="exchange_content standard_width" key={source.name}>
+              <div className="left">
+                {source.name.includes("Uniswap") && (
+                  <span className="icon_uniswap" />
+                )}
+                {source.name}
+              </div>
+              <div>{parseFloat(source.proportion) * 100}%</div>
             </div>
-            <div>{parseFloat(source.proportion) * 100}%</div>
-          </div>
-        ))}
-      </div>
-      <div className="confirm_button center_horizontal">
-        <SharedButton type="primary" size="large" onClick={handleConfirmClick}>
-          {t("continueSwap")}
-        </SharedButton>
+          ))}
+        </div>
+        <div className="confirm_button center_horizontal">
+          <SharedButton
+            type="primary"
+            size="large"
+            onClick={handleConfirmClick}
+          >
+            {t("continueSwap")}
+          </SharedButton>
+        </div>
       </div>
       <style jsx>
         {`
           section {
             margin-top: -24px;
+          }
+          .content_wrap {
+            height: 525px;
+            overflow-y: scroll;
           }
           .icon_uniswap {
             background: url("./images/uniswap@2x.png");
@@ -181,6 +191,7 @@ export default function SwapQuote({
           .confirm_button {
             width: fit-content;
             margin-top: 36px;
+            margin-bottom: 16px;
           }
           .exchange_section_wrap {
             margin-top: 16px;


### PR DESCRIPTION
Closes #2232 

This PR adds a scroll for the swap quote view.

## UI

Before

![Screenshot 2022-12-30 at 16 41 52](https://user-images.githubusercontent.com/23117945/210089736-6c10aa13-c32b-4421-bba5-572a1a25487b.png)

After

https://user-images.githubusercontent.com/23117945/210089751-96a21c6d-efa1-4107-a026-7c6aae0275d4.mov

## To Test
- select Polygon network
- try to swap Matic<>AMP


Latest build: [extension-builds-2825](https://github.com/tallyhowallet/extension/suites/10114473112/artifacts/493411996) (as of Fri, 30 Dec 2022 16:11:08 GMT).