### PR TITLE
Fix the nonce release logic

### DIFF
--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -794,7 +794,7 @@ export default class ChainService extends BaseService<Events> {
         // now-released-and-therefore-never-broadcast nonce).
         this.evmChainLastSeenNoncesByNormalizedAddress[chainID][
           normalizedAddress
-        ] = lastSeenNonce - 1
+        ] = nonce - 1
       }
     }
   }


### PR DESCRIPTION
Closes #2808 

This PR fixes the nonce release logic to set the proper nonce after a release. PR also fixes the tests implemented in the #2160.

## Background
For the chains with mempool occasionally occurs issues about transactions. This means that the user is getting consistently dropped transactions. The reason for this behavior is the wrong logic of setting the proper nonce after a release. When the nonce is set incorrectly, transactions will be dropped. 

## Test case
Two transactions have been sent: one approving (nonce=11) the other for the swapping (nonce=12). In case the transaction for nonce 11 will has too small gas, transactions for approval and swap will be rejected. The reason for this is that transactions in mempool execute sequentially. The transaction for nonce 11 also blocked transactions for nonce 12. The nonce value for the chain is 10.

The previous solution set the new `lastSeenNonce` to 11.
The current solution set the new `lastSeenNonce` to 10

Please take a look at the tests in the task #2160.

