### PR TITLE
Fix the feature flag check for daylight menu

### DIFF
--- a/ui/pages/Overview.tsx
+++ b/ui/pages/Overview.tsx
@@ -51,7 +51,7 @@ function Overview(): ReactElement {
           balance={balance}
           initializationTimeExpired={initializationLoadingTimeExpired}
         />
-        {FeatureFlags.SUPPORT_ABILITIES ? <AbilitiesHeader /> : null}
+        {isEnabled(FeatureFlags.SUPPORT_ABILITIES) ? <AbilitiesHeader /> : null}
         <AccountList
           accountsTotal={accountsTotal}
           accountsCount={accountsCount}
@@ -123,7 +123,7 @@ function NewOverview(): ReactElement {
         balance={balance}
         initializationTimeExpired={initializationLoadingTimeExpired}
       />
-      {FeatureFlags.SUPPORT_ABILITIES ? <AbilitiesHeader /> : null}
+      {isEnabled(FeatureFlags.SUPPORT_ABILITIES) ? <AbilitiesHeader /> : null}
       <AccountList
         accountsTotal={accountsTotal}
         accountsCount={accountsCount}


### PR DESCRIPTION
Previous to this change the portfolio tab was broken with the `SUPPORT_ABILITIES` false.

Latest build: [extension-builds-2858](https://github.com/tallyhowallet/extension/suites/10307285907/artifacts/506854455) (as of Wed, 11 Jan 2023 12:26:02 GMT).