### PR TITLE
Proposal: Autofocus on input when editing section name

### DIFF
--- a/ui/components/AccountsNotificationPanel/EditSectionForm.tsx
+++ b/ui/components/AccountsNotificationPanel/EditSectionForm.tsx
@@ -78,6 +78,7 @@ function EditSectionForm({
             label=""
             placeholder={t("typeNewName")}
             errorMessage={error}
+            autoFocus
             onChange={(value) => {
               if (!touched) {
                 setTouched(true)


### PR DESCRIPTION
Before: 
![before](https://media1.giphy.com/media/J8gE7ewgydEsQxnLLF/giphy.gif?cid=790b761130964052b4436da6da1427f59d1812b551ea4560&rid=giphy.gif&ct=g)

After:
![after](https://media3.giphy.com/media/gjVtStMeXWQg1i1g27/giphy.gif?cid=790b7611daa76c52e48e9f6a201c07f5357dd8e5e7d095c9&rid=giphy.gif&ct=g)

Latest build: [extension-builds-2869](https://github.com/tallyhowallet/extension/suites/10378682387/artifacts/512090440) (as of Sun, 15 Jan 2023 11:49:11 GMT).