### PR TITLE
Fix links to Twitter and Github

### DIFF
--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -32,11 +32,11 @@ const FOOTER_ACTIONS = [
   },
   {
     icon: "twitter",
-    linkTo: "https://twitter.com/TallyCash",
+    linkTo: "https://twitter.com/TallyHoOfficial",
   },
   {
     icon: "icons/m/github",
-    linkTo: "https://github.com/tallycash/extension",
+    linkTo: "https://github.com/tallyhowallet/extension",
   },
 ]
 


### PR DESCRIPTION
Resolves https://github.com/tallyhowallet/extension/issues/2871

Fix URLs for our Github and Twitter buttons
![image](https://user-images.githubusercontent.com/20949277/212658455-fcf90925-c229-49f0-a837-6d8f2320a1f1.png)


Latest build: [extension-builds-2872](https://github.com/tallyhowallet/extension/suites/10391518950/artifacts/512985953) (as of Mon, 16 Jan 2023 10:40:20 GMT).