### PR TITLE
Fix wallet control button styles

### DIFF
--- a/ui/components/Shared/SharedSquareButton.tsx
+++ b/ui/components/Shared/SharedSquareButton.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from "react"
 const SIZE = 32
 const DEFAULT_COLORS: ColorDetails = {
   color: "var(--green-40)",
-  hoverColor: "var(--trophy-gold)",
+  hoverColor: "var(--gold-80)",
 }
 
 type ColorDetails = {
@@ -70,9 +70,9 @@ export default function SharedSquareButton(props: Props): ReactElement {
             mask-repeat: no-repeat;
             mask-position: center;
             mask-size: cover;
-            mask-size: 60%;
-            width: ${size}px;
-            height: ${size}px;
+            width: ${size / 2}px;
+            height: ${size / 2}px;
+            margin: ${size / 4}px;
             background-color: var(--hunter-green);
           }
         `}

--- a/ui/components/Wallet/WalletAccountBalanceControl.tsx
+++ b/ui/components/Wallet/WalletAccountBalanceControl.tsx
@@ -48,7 +48,7 @@ function ActionButtons(props: ActionButtonsProps): ReactElement {
               onClick={() => history.push("/swap")}
               iconColor={{
                 color: "var(--trophy-gold)",
-                hoverColor: "var(--trophy-gold)",
+                hoverColor: "var(--gold-80)",
               }}
             >
               {t("swap")}


### PR DESCRIPTION
Resolves https://github.com/tallyhowallet/extension/issues/2874

### What
Fix buttons' colors and icons size
![image](https://user-images.githubusercontent.com/20949277/213126586-3ea865d2-4639-440e-9d33-bd497c2ba060.png)


Latest build: [extension-builds-2883](https://github.com/tallyhowallet/extension/suites/10434853556/artifacts/516114569) (as of Wed, 18 Jan 2023 08:58:00 GMT).