### PR TITLE
Don't display prices for untrusted assets.

### DIFF
--- a/ui/components/Wallet/AssetListItem/CommonAssetListItem.tsx
+++ b/ui/components/Wallet/AssetListItem/CommonAssetListItem.tsx
@@ -47,6 +47,8 @@ export default function CommonAssetListItem(
       ? assetAmount.asset.contractAddress
       : undefined
 
+  const assetIsUntrusted = numTokenLists === 0 && !baseAsset
+
   return (
     <Link
       to={{
@@ -67,22 +69,29 @@ export default function CommonAssetListItem(
               </span>
               <span>{assetAmount.asset.symbol}</span>
             </div>
-            {initializationLoadingTimeExpired && isMissingLocalizedUserValue ? (
-              <></>
-            ) : (
-              <div className="price">
-                {isMissingLocalizedUserValue ? (
-                  <SharedLoadingSpinner size="small" />
-                ) : (
-                  `$${assetAmount.localizedMainCurrencyAmount}`
-                )}
-              </div>
-            )}
+
+            {
+              // @TODO don't fetch prices for untrusted assets in the first place
+              // Only show prices for trusted assets
+              assetIsUntrusted ||
+              (initializationLoadingTimeExpired &&
+                isMissingLocalizedUserValue) ? (
+                <></>
+              ) : (
+                <div className="price">
+                  {isMissingLocalizedUserValue ? (
+                    <SharedLoadingSpinner size="small" />
+                  ) : (
+                    `$${assetAmount.localizedMainCurrencyAmount}`
+                  )}
+                </div>
+              )
+            }
           </div>
         </div>
         <div className="asset_right">
           <>
-            {numTokenLists === 0 && !baseAsset && (
+            {assetIsUntrusted && (
               <button
                 type="button"
                 onClick={(event) => {


### PR DESCRIPTION
Closes https://github.com/tallyhowallet/extension/issues/2904

To avoid erroneously showing prices of untrusted assets (and thus making them appear to be legitimate) we should not show the user prices for those assets.

Before:
<img width="425" alt="image" src="https://user-images.githubusercontent.com/94649004/214119151-7d6bd5bf-ce97-4ca1-856e-acf4e269d24b.png">

After:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/94649004/214119228-9b6130df-b1ed-4bae-ac0e-5055e86f1edb.png">



### To Test
- [ ] Import the test wallet
- [ ] Switch to Polygon
- [ ] The scam asset `AAVE` should be marked as untrusted and should not display a price

Latest build: [extension-builds-2902](https://github.com/tallyhowallet/extension/suites/10533600698/artifacts/523529251) (as of Mon, 23 Jan 2023 18:26:35 GMT).