### PR TITLE
Reset transaction fee type on network switch

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1278,6 +1278,7 @@ export default class Main extends BaseService<never> {
         [{ chainId: network.chainID }],
         TALLY_INTERNAL_ORIGIN
       )
+      this.chainService.pollBlockPricesForNetwork(network.chainID)
       this.store.dispatch(clearCustomGas())
     })
   }

--- a/background/redux-slices/tests/transaction-construction.unit.test.ts
+++ b/background/redux-slices/tests/transaction-construction.unit.test.ts
@@ -1,0 +1,21 @@
+import reducer, {
+  clearCustomGas,
+  initialState,
+  NetworkFeeTypeChosen,
+} from "../transaction-construction"
+
+describe("Transaction Construction Redux Slice", () => {
+  describe("Actions", () => {
+    describe("clearCustomGas", () => {
+      it("Should reset selected fee type to Regular", () => {
+        const mockState = {
+          ...initialState,
+          feeTypeSeected: NetworkFeeTypeChosen.Custom,
+        }
+
+        const newState = reducer(mockState, clearCustomGas())
+        expect(newState.feeTypeSelected).toBe(NetworkFeeTypeChosen.Regular)
+      })
+    })
+  })
+})

--- a/background/redux-slices/transaction-construction.ts
+++ b/background/redux-slices/transaction-construction.ts
@@ -328,6 +328,7 @@ const transactionSlice = createSlice({
     },
     clearCustomGas: (immerState) => {
       immerState.customFeesPerGas = defaultCustomGas
+      immerState.feeTypeSelected = NetworkFeeTypeChosen.Regular
     },
     setCustomGasLimit: (
       immerState,


### PR DESCRIPTION
Closes #2905 

Since we were resetting custom gas values to 0 on network switch but not the fee type selected - sending a transaction on a new network after using custom gas settings resulted in gas transactions being sent with gas values set to 0 - which would cause the transaction to fail.

### To Test
- [ ] Send a transaction with a custom gas limit on Arbitrum.
- [ ] Switch to Polygon inside of the wallet.
- [ ] Send another transaction - the transaction should succeed!

Latest build: [extension-builds-2903](https://github.com/tallyhowallet/extension/suites/10535670807/artifacts/523684007) (as of Mon, 23 Jan 2023 20:13:46 GMT).