### PR TITLE
Properly use isEnabled to gate abilities polling based on feature flag.

### DIFF
--- a/background/services/abilities/index.ts
+++ b/background/services/abilities/index.ts
@@ -8,7 +8,7 @@ import {
 } from "./daylight"
 import { AbilitiesDatabase, getOrCreateDB } from "./db"
 import ChainService from "../chain"
-import { FeatureFlags } from "../../features"
+import { FeatureFlags, isEnabled } from "../../features"
 import { normalizeEVMAddress } from "../../lib/utils"
 
 export type AbilityType = "mint" | "airdrop" | "access"
@@ -149,7 +149,7 @@ export default class AbilitiesService extends BaseService<Events> {
   }
 
   async pollForAbilities(address: HexString): Promise<void> {
-    if (!FeatureFlags.SUPPORT_ABILITIES) {
+    if (!isEnabled(FeatureFlags.SUPPORT_ABILITIES)) {
       return
     }
 


### PR DESCRIPTION
Closes #2908 

The previous implementation does not allow for runtime switches.  The pattern here matches how we check for feature flags in all other instances.

Latest build: [extension-builds-2907](https://github.com/tallyhowallet/extension/suites/10536438251/artifacts/523740197) (as of Mon, 23 Jan 2023 20:53:32 GMT).