### PR TITLE
Impersonate MetaMask on CowSwap

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -56,6 +56,7 @@ const impersonateMetamaskWhitelist = [
   "mint.xencrypto.io",
   "bscscan.com",
   "alchemy.com",
+  "cow.fi",
 ]
 
 const METAMASK_STATE_MOCK = {


### PR DESCRIPTION
### Testing

- set wallet as default
- have metamask enabled on the browser
- try to connect wallet to [CowSwap](https://swap.cow.fi/#/1/swap/WETH)
- you should connect to TallyHo

Latest build: [extension-builds-2916](https://github.com/tallyhowallet/extension/suites/10555825810/artifacts/525096196) (as of Tue, 24 Jan 2023 16:28:34 GMT).