### PR TITLE
Disable Sign button if user can't pay fees

### DIFF
--- a/ui/components/Signing/Signer/SignerBaseFrame.tsx
+++ b/ui/components/Signing/Signer/SignerBaseFrame.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { selectTransactionData } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
+import { useBackgroundSelector } from "../../../hooks"
 import SharedButton from "../../Shared/SharedButton"
 
 type SignerBaseFrameProps = {
@@ -17,6 +19,10 @@ export default function SignerBaseFrame({
 }: SignerBaseFrameProps): ReactElement {
   const { t } = useTranslation("translation", { keyPrefix: "signTransaction" })
 
+  const transactionDetails = useBackgroundSelector(selectTransactionData)
+  const hasInsufficientFunds =
+    transactionDetails?.annotation?.warnings?.includes("insufficient-funds")
+
   const [isOnDelayToSign /* , setIsOnDelayToSign */] = useState(false)
 
   return (
@@ -32,7 +38,7 @@ export default function SignerBaseFrame({
           size="large"
           onClick={onConfirm}
           showLoadingOnClick
-          isDisabled={isOnDelayToSign}
+          isDisabled={hasInsufficientFunds || isOnDelayToSign}
         >
           {signingActionLabel}
         </SharedButton>


### PR DESCRIPTION
Before:
![before](https://media1.giphy.com/media/YlC2B3uJsB4d2AoQW2/giphy.gif?cid=790b7611ec38b3a15feb1f850c005c536ed4db41d2833f08&rid=giphy.gif&ct=g)

After:
![after](https://media0.giphy.com/media/75WaEPclwFZFRmVmtJ/giphy.gif?cid=790b76116406cc035101bcefa8513f9787b32ce3dfd18a80&rid=giphy.gif&ct=g)

Fixes #2912

Latest build: [extension-builds-2917](https://github.com/tallyhowallet/extension/suites/10557396288/artifacts/525210443) (as of Tue, 24 Jan 2023 17:35:55 GMT).