### PR TITLE
Fix label background in SharedInput

### DIFF
--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -153,7 +153,6 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
             width: fit-content;
             margin-left: 16px;
             transform: translateY(-32px);
-            background-color: ${focusedLabelBackgroundColor};
             border-radius: 5px;
             box-sizing: border-box;
             color: var(--green-40);
@@ -181,6 +180,7 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
             font-size: 12px;
             font-weight: 500;
             padding: 0px 6px;
+            background-color: ${focusedLabelBackgroundColor};
           }
           .error ~ label,
           input.error:focus ~ label {

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -153,6 +153,7 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
             width: fit-content;
             margin-left: 16px;
             transform: translateY(-32px);
+            background-color: ${focusedLabelBackgroundColor};
             border-radius: 5px;
             box-sizing: border-box;
             color: var(--green-40);
@@ -170,13 +171,8 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
             border-color: var(--trophy-gold);
           }
 
-          input[data-empty="false"] ~ label {
-            background-color: ${focusedLabelBackgroundColor};
-          }
-
           input:focus ~ label {
             color: var(--trophy-gold);
-            background-color: ${focusedLabelBackgroundColor};
           }
           input:focus ~ label,
           input:not(:placeholder-shown) ~ label,


### PR DESCRIPTION
Before:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/7405155/214376753-f90fe4f2-622d-4013-abb8-b010d058e64c.png">

After:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/7405155/214376605-4ac90db1-924f-4078-bca7-b9b1fe7d9cdc.png">

Fixes #2909

Latest build: [extension-builds-2918](https://github.com/tallyhowallet/extension/suites/10585916210/artifacts/527334315) (as of Wed, 25 Jan 2023 21:52:22 GMT).