### PR TITLE
Hide untrusted assets with hide dust option

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -141,10 +141,12 @@ const computeCombinedAssetAmountsData = (
           ? true
           : assetAmount.mainCurrencyAmount > userValueDustThreshold
       const isPresent = assetAmount.decimalAmount > 0
+      const isTrusted = !!(assetAmount.asset?.metadata?.tokenLists.length ?? 0)
 
-      // Hide dust and missing amounts.
+      // Hide dust, untrusted assets and missing amounts.
       return (
-        isForciblyDisplayed || (hideDust ? isNotDust && isPresent : isPresent)
+        isForciblyDisplayed ||
+        (hideDust ? isTrusted && isNotDust && isPresent : isPresent)
       )
     })
     .sort((asset1, asset2) => {


### PR DESCRIPTION
### What
To make the spam tokens less visible it let's allow to hide them with `Hide asset balances under $2` settings option

https://user-images.githubusercontent.com/20949277/214821734-b2f3d649-f65c-481c-87eb-22468ca0ff56.mov



Latest build: [extension-builds-2927](https://github.com/tallyhowallet/extension/suites/10595543874/artifacts/528090668) (as of Thu, 26 Jan 2023 11:14:13 GMT).