### PR TITLE
NFTs preview improvements

### DIFF
--- a/background/lib/poap_update.ts
+++ b/background/lib/poap_update.ts
@@ -3,7 +3,7 @@ import logger from "./logger"
 import { ETHEREUM } from "../constants"
 import { NFT, NFTCollection, NFTsWithPagesResponse } from "../nfts"
 
-export const POAP_CONTRACT = "poap_contract"
+export const POAP_CONTRACT = "0x22C1f6050E56d2876009903609a2cC3fEf83B415" // POAP contract address https://etherscan.io/address/0x22C1f6050E56d2876009903609a2cC3fEf83B415
 export const POAP_COLLECTION_ID = "POAP"
 
 type PoapNFTModel = {
@@ -39,6 +39,7 @@ function poapNFTModelToNFT(original: PoapNFTModel, owner: string): NFT {
       country,
       city,
       year,
+      supply,
     },
   } = original
   return {
@@ -58,6 +59,7 @@ function poapNFTModelToNFT(original: PoapNFTModel, owner: string): NFT {
     contract: POAP_CONTRACT, // contract address doesn't make sense for POAPs
     owner,
     network: ETHEREUM,
+    supply,
     isBadge: true,
   }
 }

--- a/background/nfts.ts
+++ b/background/nfts.ts
@@ -54,7 +54,8 @@ export type NFT = {
   contract: string
   owner: string
   network: EVMNetwork
-  isBadge: boolean
+  supply?: number // only for POAPs
+  isBadge: boolean // POAPs, Galxe NFTs and OATs
 }
 
 export type NFTCollection = {

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -29,7 +29,7 @@ export const enum AccountType {
   Internal = "internal",
 }
 
-const availableDefaultNames = [
+export const DEFAULT_ACCOUNT_NAMES = [
   "Phoenix",
   "Matilda",
   "Sirius",
@@ -39,6 +39,8 @@ const availableDefaultNames = [
   "Lola",
   "Foz",
 ]
+
+const availableDefaultNames = [...DEFAULT_ACCOUNT_NAMES]
 
 export type AccountData = {
   address: HexString

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -1,7 +1,11 @@
 import { createSelector } from "@reduxjs/toolkit"
 import { selectHideDust } from "../ui"
 import { RootState } from ".."
-import { AccountType, CompleteAssetAmount } from "../accounts"
+import {
+  AccountType,
+  DEFAULT_ACCOUNT_NAMES,
+  CompleteAssetAmount,
+} from "../accounts"
 import { AssetsState, selectAssetPricePoint } from "../assets"
 import {
   enrichAssetAmountWithDecimalValues,
@@ -516,6 +520,17 @@ export const getAccountTotal = (
     ),
     accountAddressOnNetwork
   )
+
+export const getAccountNameOnChain = (
+  state: RootState,
+  accountAddressOnNetwork: AddressOnNetwork
+): string | undefined => {
+  const account = getAccountTotal(state, accountAddressOnNetwork)
+
+  return account?.name && !DEFAULT_ACCOUNT_NAMES.includes(account.name)
+    ? account.name
+    : undefined
+}
 
 export const selectCurrentAccountTotal = createSelector(
   selectCurrentNetworkAccountTotalsByCategory,

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -1,13 +1,10 @@
 import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
-import {
-  isProbablyEVMAddress,
-  truncateAddress,
-} from "@tallyho/tally-background/lib/utils"
 import { NFTWithCollection } from "@tallyho/tally-background/redux-slices/nfts_update"
 import React, { ReactElement, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useIntersectionObserver } from "../../hooks"
 import { trimWithEllipsis } from "../../utils/textUtils"
+import SharedAddress from "../Shared/SharedAddress"
 import SharedButton from "../Shared/SharedButton"
 import SharedNetworkIcon from "../Shared/SharedNetworkIcon"
 import ExploreMarketLink, { getRelevantMarketsList } from "./ExploreMarketLink"
@@ -38,6 +35,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
     owner,
     description,
     attributes,
+    supply,
     isBadge,
   } = nft
   const { totalNftCount } = collection
@@ -87,7 +85,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
                 {t("preview.owner")}
               </span>
               <span className="preview_details_value">
-                {truncateAddress(owner)}
+                <SharedAddress address={owner} elide />
               </span>
             </div>
             <div className="preview_section_column align_right">
@@ -153,13 +151,15 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
             <div className="preview_section_header">
               {t("preview.itemsCount")}
             </div>
-            <p>{totalNftCount ?? "-"}</p>
+            <p>{totalNftCount ?? supply ?? "-"}</p>
           </div>
           <div className="preview_section_column align_right">
             <div className="preview_section_header">{t("preview.creator")}</div>
-            <p>
-              {isProbablyEVMAddress(contract) ? truncateAddress(contract) : "-"}
-            </p>
+            {contract?.length ? (
+              <SharedAddress address={contract} elide />
+            ) : (
+              "-"
+            )}
           </div>
         </div>
 

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -1,8 +1,9 @@
 import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import { NFTWithCollection } from "@tallyho/tally-background/redux-slices/nfts_update"
+import { getAccountNameOnChain } from "@tallyho/tally-background/redux-slices/selectors"
 import React, { ReactElement, useMemo } from "react"
 import { useTranslation } from "react-i18next"
-import { useIntersectionObserver } from "../../hooks"
+import { useBackgroundSelector, useIntersectionObserver } from "../../hooks"
 import { trimWithEllipsis } from "../../utils/textUtils"
 import SharedAddress from "../Shared/SharedAddress"
 import SharedButton from "../Shared/SharedButton"
@@ -43,6 +44,10 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
     "floorPrice" in collection &&
     collection.floorPrice?.value !== undefined &&
     collection.floorPrice
+
+  const ownerName = useBackgroundSelector((state) =>
+    getAccountNameOnChain(state, { address: owner, network })
+  )
 
   // Chrome seems to have problems when elements with backdrop style are rendered initially
   // out of the viewport - browser is not rendering them at all. This is a workaround
@@ -85,7 +90,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
                 {t("preview.owner")}
               </span>
               <span className="preview_details_value">
-                <SharedAddress address={owner} elide />
+                <SharedAddress address={owner} name={ownerName} elide />
               </span>
             </div>
             <div className="preview_section_column align_right">

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -93,7 +93,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
                 <SharedAddress address={owner} name={ownerName} elide />
               </span>
             </div>
-            <div className="preview_section_column align_right">
+            <div className="preview_section_column align_right no_shrink">
               <span className="preview_details_header">
                 {t("preview.floorPrice")}
               </span>
@@ -266,6 +266,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
         .preview_section_column {
           display: flex;
           flex-direction: column;
+          min-width: 0;
         }
         .preview_section_row {
           display: flex;
@@ -313,6 +314,9 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
           margin-top: 8px;
           gap: 16px;
           justify-content: flex-start;
+        }
+        .no_shrink {
+          flex-shrink: 0;
         }
       `}</style>
     </>

--- a/ui/components/Shared/SharedAddress.tsx
+++ b/ui/components/Shared/SharedAddress.tsx
@@ -74,6 +74,7 @@ export default function SharedAddress({
       <style jsx>{`
         button {
           transition: 300ms color;
+          max-width: 100%;
         }
         button :last-child {
           top: 3px;


### PR DESCRIPTION
Resolves https://github.com/tallyhowallet/extension/issues/2848

### What

- display POAPs supply for a given event on the Preview slideup
- add hardcoded POAPs contract as a contract address
- make addresses on the Preview slideup clickable
- show resolved account names instead of addresses if account has ENS/UNS name

![image](https://user-images.githubusercontent.com/20949277/214846188-c64d5d25-7ef9-4f6b-8b39-4d8d7eb080d0.png)


Latest build: [extension-builds-2928](https://github.com/tallyhowallet/extension/suites/10597919968/artifacts/528262541) (as of Thu, 26 Jan 2023 13:27:13 GMT).