### PR TITLE
Update default Avalanche token list

### DIFF
--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -268,6 +268,25 @@ export class PreferenceDatabase extends Dexie {
         })
     })
 
+    this.version(14).upgrade((tx) => {
+      return tx
+        .table("preferences")
+        .toCollection()
+        .modify((storedPreferences: Preferences) => {
+          const urls = storedPreferences.tokenLists.urls.filter(
+            (url) =>
+              url !==
+              "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/src/joe.tokenlist-v2.json"
+          )
+
+          urls.push(
+            "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/avalanche.tokenlist.json"
+          )
+
+          Object.assign(storedPreferences.tokenLists, { urls })
+        })
+    })
+
     // This is the old version for populate
     // https://dexie.org/docs/Dexie/Dexie.on.populate-(old-version)
     // The this does not behave according the new docs, but works

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -18,7 +18,7 @@ const defaultPreferences: Preferences = {
       "https://api-polygon-tokens.polygon.technology/tokenlists/default.tokenlist.json", // Polygon Default Tokens
       "https://static.optimism.io/optimism.tokenlist.json", // Optimism Default Tokens
       "https://bridge.arbitrum.io/token-list-42161.json", // Arbitrum Default tokens
-      "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/src/joe.tokenlist-v2.json", // Trader Joe tokens
+      "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/avalanche.tokenlist.json", // Trader Joe tokens
       "https://tokens.pancakeswap.finance/pancakeswap-default.json", // PancakeSwap Default List
     ],
   },


### PR DESCRIPTION
Updates the default and the existing token list stored in preferences

## To Test: 
- [ ] Reinstall the extension, import an account that has avalanche tokens and switch to avalanche.

Latest build: [extension-builds-2932](https://github.com/tallyhowallet/extension/suites/10614716265/artifacts/529521072) (as of Fri, 27 Jan 2023 07:01:20 GMT).