### PR TITLE
Prevent price point best effort matching for untrusted assets

### DIFF
--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -223,6 +223,11 @@ export const selectAssetPricePoint = createSelector(
           asset.homeNetwork.chainID === assetToFind.homeNetwork.chainID &&
           hasRecentPriceData(asset)
       )
+
+      /* Don't do anything else if this is an untrusted asset and there's no exact match */
+      if ((assetToFind.metadata?.tokenLists.length ?? 0) < 1) {
+        return undefined
+      }
     }
 
     /* Otherwise, find a best-effort match by looking for assets with the same symbol  */

--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -225,7 +225,10 @@ export const selectAssetPricePoint = createSelector(
       )
 
       /* Don't do anything else if this is an untrusted asset and there's no exact match */
-      if ((assetToFind.metadata?.tokenLists.length ?? 0) < 1) {
+      if (
+        (assetToFind.metadata?.tokenLists.length ?? 0) < 1 &&
+        !isBuiltInNetworkBaseAsset(assetToFind, assetToFind.homeNetwork)
+      ) {
         return undefined
       }
     }

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -88,10 +88,6 @@ const computeCombinedAssetAmountsData = (
   combinedAssetAmounts: CompleteAssetAmount[]
   totalMainCurrencyAmount: number | undefined
 } => {
-  // Keep a tally of the total user value; undefined if no main currency data
-  // is available.
-  let totalMainCurrencyAmount: number | undefined
-
   // Derive account "assets"/assetAmount which include USD values using
   // data from the assets slice
   const combinedAssetAmounts = assetAmounts
@@ -120,11 +116,6 @@ const computeCombinedAssetAmountsData = (
           mainCurrencyEnrichedAssetAmount.unitPrice
         )
       )
-
-      if (typeof fullyEnrichedAssetAmount.mainCurrencyAmount !== "undefined") {
-        totalMainCurrencyAmount ??= 0 // initialize if needed
-        totalMainCurrencyAmount += fullyEnrichedAssetAmount.mainCurrencyAmount
-      }
 
       return fullyEnrichedAssetAmount
     })
@@ -205,6 +196,16 @@ const computeCombinedAssetAmountsData = (
       // If only one asset has a main currency amount, it wins.
       return asset1.mainCurrencyAmount === undefined ? 1 : -1
     })
+
+  // Keep a tally of the total user value; undefined if no main currency data
+  // is available.
+  let totalMainCurrencyAmount: number | undefined
+  combinedAssetAmounts.forEach((assetAmount) => {
+    if (typeof assetAmount.mainCurrencyAmount !== "undefined") {
+      totalMainCurrencyAmount ??= 0 // initialize if needed
+      totalMainCurrencyAmount += assetAmount.mainCurrencyAmount
+    }
+  })
 
   return { combinedAssetAmounts, totalMainCurrencyAmount }
 }


### PR DESCRIPTION
Do not fall back to best effort matches when retrieving price points for untrusted assets

### Before
![image](https://user-images.githubusercontent.com/28708889/215033825-741c6339-358e-4bcd-8940-feaaead1b33f.png)

### After
![image](https://user-images.githubusercontent.com/28708889/215031815-6b513356-f72e-459a-ae5d-467baa5403c7.png)


## To Test
- [ ] Load an account, check balances in the main and the overview page
- [ ] Smart contract assets that are discovered from token transfers should not display price data unless there's information for that  exact contract address

Latest build: [extension-builds-2933](https://github.com/tallyhowallet/extension/suites/10657658900/artifacts/532691947) (as of Mon, 30 Jan 2023 10:12:37 GMT).