### PR TITLE
Fix issues for abilities page

### DIFF
--- a/background/redux-slices/utils/abilities-utils.ts
+++ b/background/redux-slices/utils/abilities-utils.ts
@@ -1,19 +1,27 @@
 import { Ability, AbilityType } from "../../abilities"
 import { Filter, State } from "../abilities"
 
+const isDeleted = (ability: Ability): boolean => ability.removedFromUi
+
+const isExpired = (ability: Ability): boolean =>
+  ability.closeAt ? new Date(ability.closeAt) < new Date() : false
+
 export const filterByState = (ability: Ability, state: State): boolean => {
   switch (state) {
     case "open":
-      return ability.completed === false && !ability.removedFromUi
-    case "completed":
-      return ability.completed === true && !ability.removedFromUi
-    case "expired":
       return (
-        (ability.closeAt ? new Date(ability.closeAt) < new Date() : false) &&
-        !ability.removedFromUi
+        !isDeleted(ability) &&
+        !isExpired(ability) &&
+        ability.completed === false
       )
+    case "completed":
+      return (
+        !isDeleted(ability) && !isExpired(ability) && ability.completed === true
+      )
+    case "expired":
+      return !isDeleted(ability) && isExpired(ability)
     case "deleted":
-      return ability.removedFromUi
+      return isDeleted(ability)
     default:
       return true
   }

--- a/background/redux-slices/utils/tests/abilities-utils.unit.test.ts
+++ b/background/redux-slices/utils/tests/abilities-utils.unit.test.ts
@@ -37,6 +37,13 @@ describe("Abilities utils", () => {
       }
       expect(filterByState(ability, "open")).toBeFalsy()
     })
+    test("should return false if an ability is open and expired", () => {
+      const ability = {
+        ...ABILITY_DEFAULT,
+        closeAt: "Thu Mar 31 2022",
+      }
+      expect(filterByState(ability, "open")).toBeFalsy()
+    })
     test("should return true if an ability is completed", () => {
       const ability = {
         ...ABILITY_DEFAULT,
@@ -49,6 +56,14 @@ describe("Abilities utils", () => {
         ...ABILITY_DEFAULT,
         completed: true,
         removedFromUi: true,
+      }
+      expect(filterByState(ability, "completed")).toBeFalsy()
+    })
+    test("should return false if an ability is completed and expired", () => {
+      const ability = {
+        ...ABILITY_DEFAULT,
+        completed: true,
+        closeAt: "Thu Mar 31 2022",
       }
       expect(filterByState(ability, "completed")).toBeFalsy()
     })

--- a/ui/pages/Abilities/AbilityCard.tsx
+++ b/ui/pages/Abilities/AbilityCard.tsx
@@ -18,12 +18,14 @@ const getTimeDetails = (ability: Ability): string => {
   cutOffDate.setDate(cutOffDate.getDate() + DAYS)
 
   if (ability.closeAt) {
-    if (new Date(ability.closeAt) < cutOffDate) {
+    const closeDate = new Date(ability.closeAt)
+    if (new Date() < closeDate && closeDate < cutOffDate) {
       return i18n.t("abilities.timeCloses")
     }
   }
   if (ability.openAt) {
-    if (new Date(ability.openAt) < cutOffDate) {
+    const openDate = new Date(ability.openAt)
+    if (new Date() < openDate && openDate < cutOffDate) {
       return i18n.t("abilities.timeStarting")
     }
   }

--- a/ui/pages/Abilities/__tests__/AbilityCard.test.tsx
+++ b/ui/pages/Abilities/__tests__/AbilityCard.test.tsx
@@ -10,7 +10,7 @@ const TIME_DETAILS = {
 }
 
 describe("AbilityCard", () => {
-  it("should render a component", async () => {
+  it("should render a component", () => {
     const ability = createAbility()
     const ui = renderWithProviders(<AbilityCard ability={ability} />, {
       preloadedState: { account: createAccountState() },
@@ -19,7 +19,7 @@ describe("AbilityCard", () => {
     expect(ui.getByText(ability.title)).toBeInTheDocument()
   })
 
-  it("should not display the time detail message", async () => {
+  it("should not display the time detail message", () => {
     const ui = renderWithProviders(<AbilityCard ability={createAbility()} />, {
       preloadedState: { account: createAccountState() },
     })
@@ -28,7 +28,7 @@ describe("AbilityCard", () => {
     expect(ui.queryByText(TIME_DETAILS.close)).not.toBeInTheDocument()
   })
 
-  it("should display a message that the ability starts within a month", async () => {
+  it("should display a message that the ability starts within a month", () => {
     // The ability start date is in two weeks
     const date = new Date()
     date.setDate(date.getDate() + 2 * 7)
@@ -42,7 +42,7 @@ describe("AbilityCard", () => {
     expect(ui.queryByText(TIME_DETAILS.start)).toBeInTheDocument()
   })
 
-  it("should display a message that the ability closes within a month", async () => {
+  it("should display a message that the ability closes within a month", () => {
     // The deadline for closing ability is in two weeks
     const date = new Date()
     date.setDate(date.getDate() + 2 * 7)
@@ -56,7 +56,7 @@ describe("AbilityCard", () => {
     expect(ui.queryByText(TIME_DETAILS.close)).toBeInTheDocument()
   })
 
-  it("should not display the time detail message when the date does not occur within 30 consecutive days", async () => {
+  it("should not display the time detail message when the date does not occur within 30 consecutive days", () => {
     // Start in 5 weeks
     const openAt = new Date()
     openAt.setDate(openAt.getDate() + 5 * 7)
@@ -71,6 +71,34 @@ describe("AbilityCard", () => {
           closeAt: closeAt.toDateString(),
         })}
       />,
+      {
+        preloadedState: { account: createAccountState() },
+      }
+    )
+    expect(ui.queryByText(TIME_DETAILS.start)).not.toBeInTheDocument()
+    expect(ui.queryByText(TIME_DETAILS.close)).not.toBeInTheDocument()
+  })
+
+  it("should not display the time detail message when the ability is expired", () => {
+    const date = new Date()
+    date.setDate(date.getDate() - 1)
+
+    const ui = renderWithProviders(
+      <AbilityCard ability={createAbility({ closeAt: date.toDateString() })} />,
+      {
+        preloadedState: { account: createAccountState() },
+      }
+    )
+    expect(ui.queryByText(TIME_DETAILS.start)).not.toBeInTheDocument()
+    expect(ui.queryByText(TIME_DETAILS.close)).not.toBeInTheDocument()
+  })
+
+  it("should not display the time detail message when the ability is open", () => {
+    const date = new Date()
+    date.setDate(date.getDate() - 1)
+
+    const ui = renderWithProviders(
+      <AbilityCard ability={createAbility({ openAt: date.toDateString() })} />,
       {
         preloadedState: { account: createAccountState() },
       }

--- a/ui/pages/Abilities/__tests__/AbilityCardHeader.test.tsx
+++ b/ui/pages/Abilities/__tests__/AbilityCardHeader.test.tsx
@@ -10,7 +10,7 @@ import { renderWithProviders } from "../../../tests/test-utils"
 import AbilityCardHeader from "../AbilityCardHeader"
 
 describe("AbilityCardHeader", () => {
-  it("should display an ENS name", async () => {
+  it("should display an ENS name", () => {
     const account = createAccountState()
     const accountData = account.accountsData.evm[ETHEREUM.chainID][
       TEST_ADDRESS
@@ -26,7 +26,7 @@ describe("AbilityCardHeader", () => {
     expect(ui.queryByText(accountData.ens.name)).toBeInTheDocument()
   })
 
-  it("should display a shortened address when an ENS name is unavailable", async () => {
+  it("should display a shortened address when an ENS name is unavailable", () => {
     const account = createAccountState()
     const accountData = createAccountData({ ens: {} })
     account.accountsData.evm[ETHEREUM.chainID][TEST_ADDRESS] = accountData


### PR DESCRIPTION
Closes #2946 

This PR fixes issues for the abilities page. Changes: 

* fix the issue of filtering expired abilities
* display correct time details label

## UI
Before

After

## To Test
- [ ] try to filter out "open" abilities from "expired" abilities

## Testing Env
```
SUPPORT_ABILITIES=true
```