### PR TITLE
⚠Wallet Connect - Display dApp info when connecting the wallet through

### DIFF
--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -33,6 +33,9 @@ type Events = ServiceLifecycleEvents & {
   requestPermission: PermissionRequest
   initializeAllowedPages: PermissionMap
   setClaimReferrer: string
+  /**
+   * Contains the Wallet Connect URI required to pair/connect
+   */
   walletConnectInit: string
 }
 
@@ -165,17 +168,16 @@ export default class ProviderBridgeService extends BaseService<Events> {
 
           this.emitter.emit("setClaimReferrer", String(event.request.params[0]))
           break
-        case "tally_walletConnectInit":
-          if (typeof event.request.params[0] !== "string") {
+        case "tally_walletConnectInit": {
+          const [wcUri] = event.request.params
+          if (typeof wcUri === "string") {
+            await this.emitter.emit("walletConnectInit", wcUri)
+          } else {
             logger.warn(`invalid 'tally_walletConnectInit' request`)
-            return
           }
 
-          await this.emitter.emit(
-            "walletConnectInit",
-            String(event.request.params[0])
-          )
           break
+        }
         default:
           logger.debug(
             `Unknown method ${event.request.method} in 'ProviderBridgeService'`

--- a/background/services/wallet-connect/legacy-sign-client-helper.ts
+++ b/background/services/wallet-connect/legacy-sign-client-helper.ts
@@ -17,11 +17,11 @@ export type LegacyEventData = {
   id: number
   topic: string
   method: string
-  params: any[]
+  params: unknown[]
 }
 
 type SessionProposalListener = (payload: LegacyProposal) => void
-type SessionRequestListener = (payload: any) => void
+type SessionRequestListener = (payload: LegacyEventData) => void
 
 let legacySignClient: LegacySignClient | undefined
 
@@ -135,7 +135,7 @@ export function processLegacyRequestParams(
 
 export async function postLegacyApprovalResponse(
   event: TranslatedRequestParams,
-  payload: any
+  payload: string
 ): Promise<void> {
   const { id } = event
   const { result } = approveEIP155Request(event, payload)


### PR DESCRIPTION
Closes #2950 

Retrieves favicon url / dApp name from the Wallet Connect session proposal metadata


## Testing Env

```
SUPPORT_WALLET_CONNECT=true
```

## To Test
- [ ] Head over to [Uniswap](https://app.uniswap.org/#/swap)
- [ ] Try to connect through Wallet Connect
- [ ] Check that the icon / name displays correctly in the connection popup

Latest build: [extension-builds-2963](https://github.com/tallyhowallet/extension/suites/10704456820/artifacts/536148379) (as of Wed, 01 Feb 2023 06:05:29 GMT).