### PR TITLE
Hide Wallet Connect connection icon behind feature flag

### DIFF
--- a/ui/components/TopMenu/TopMenu.tsx
+++ b/ui/components/TopMenu/TopMenu.tsx
@@ -140,7 +140,8 @@ export default function TopMenu(): ReactElement {
                 )
               }}
             >
-              {isConnectedToDApp ? (
+              {isEnabled(FeatureFlags.SUPPORT_WALLET_CONNECT) &&
+              isConnectedToDApp ? (
                 <div className="connected-wc" />
               ) : (
                 <div className="connection_img" />


### PR DESCRIPTION
### What
Hide the icon behind a feature flag 

Latest build: [extension-builds-2975](https://github.com/tallyhowallet/extension/suites/10735550953/artifacts/538435581) (as of Thu, 02 Feb 2023 11:21:48 GMT).