### PR TITLE
Fix comparing assets to decide if they are the same base assets

### DIFF
--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -9,6 +9,7 @@ import {
   UnitPricePoint,
   AnyAsset,
   CoinGeckoAsset,
+  isSmartContractFungibleAsset,
 } from "../../assets"
 import {
   BUILT_IN_NETWORK_BASE_ASSETS,
@@ -47,14 +48,26 @@ function hasChainID(asset: AnyAsset): asset is NetworkBaseAsset {
 }
 
 function isOptimismBaseAsset(asset: AnyAsset) {
+  const hasMatchingChainID =
+    (isSmartContractFungibleAsset(asset) &&
+      asset.homeNetwork.chainID === OPTIMISM.chainID) ||
+    (hasChainID(asset) && asset.chainID === OPTIMISM.chainID)
+
   return (
+    hasMatchingChainID &&
     "contractAddress" in asset &&
     asset.contractAddress === OPTIMISM.baseAsset.contractAddress
   )
 }
 
 function isPolygonBaseAsset(asset: AnyAsset) {
+  const hasMatchingChainID =
+    (isSmartContractFungibleAsset(asset) &&
+      asset.homeNetwork.chainID === POLYGON.chainID) ||
+    (hasChainID(asset) && asset.chainID === POLYGON.chainID)
+
   return (
+    hasMatchingChainID &&
     "contractAddress" in asset &&
     asset.contractAddress === POLYGON.baseAsset.contractAddress
   )
@@ -99,6 +112,37 @@ export function getBuiltInNetworkBaseAsset(
 ): (NetworkBaseAsset & Required<CoinGeckoAsset>) | undefined {
   return BUILT_IN_NETWORK_BASE_ASSETS.find(
     (asset) => asset.symbol === symbol && asset.chainID === chainID
+  )
+}
+
+/**
+ * @param asset1 any asset
+ * @param asset2 any asset
+ * @returns true if both assets are the same network base assets
+ */
+export function sameBuiltInNetworkBaseAsset(
+  asset1: AnyAsset,
+  asset2: AnyAsset
+): boolean {
+  // for base assets with possible homeNetwork field
+  if (isOptimismBaseAsset(asset1) && isOptimismBaseAsset(asset2)) return true
+
+  if (isPolygonBaseAsset(asset1) && isPolygonBaseAsset(asset2)) return true
+
+  // for other base assets
+  if (
+    "homeNetwork" in asset1 ||
+    "homeNetwork" in asset2 ||
+    !hasChainID(asset1) ||
+    !hasChainID(asset2)
+  ) {
+    return false
+  }
+
+  return (
+    asset1.symbol === asset2.symbol &&
+    asset1.chainID === asset2.chainID &&
+    asset1.name === asset2.name
   )
 }
 


### PR DESCRIPTION
### What
It fixes a problem with no ETH asset in the swaps "buy" selector. That's only one place it was noticeable but there may be more.

### How
Prev solution assumed we could use names to compare assets but multiple chains named their base asset "Ether" so it became a problem because Ether on Optimism and Arbitrum were treated as duplicates and were missing from cached assets. 
This PR adds util for base assets comparison based on multiple factors. It also made an exception for Optimism and Polygon as these base assets are treated like tokens and have a `homeNetwork` field.

### Testing
- check contents of assets redux slice - filter for all assets named "Ether" - check if these are base assets for all networks that have Ether as a base asset
- check Swap selectors - it should be possible to swap to and from base assets