### PR TITLE
 Change visibility for Abilities

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -43,6 +43,7 @@ import { Eligible } from "./services/doggo/types"
 
 import rootReducer from "./redux-slices"
 import {
+  AccountType,
   deleteAccount,
   loadAccount,
   updateAccountBalance,
@@ -601,7 +602,7 @@ export default class Main extends BaseService<never> {
   ): Promise<void> {
     this.store.dispatch(deleteAccount(address))
 
-    if (signer.type !== "read-only" && lastAddressInAccount) {
+    if (signer.type !== AccountType.ReadOnly && lastAddressInAccount) {
       await this.preferenceService.deleteAccountSignerSettings(signer)
     }
 
@@ -620,7 +621,7 @@ export default class Main extends BaseService<never> {
     // remove abilities
     if (
       isEnabled(FeatureFlags.SUPPORT_ABILITIES) &&
-      signer.type !== "read-only"
+      signer.type !== AccountType.ReadOnly
     ) {
       await this.abilitiesService.deleteAbilitiesForAccount(address)
     }

--- a/background/main.ts
+++ b/background/main.ts
@@ -617,7 +617,10 @@ export default class Main extends BaseService<never> {
       await this.nftsService.removeNFTsForAddress(address)
     }
     // remove abilities
-    if (isEnabled(FeatureFlags.SUPPORT_ABILITIES)) {
+    if (
+      isEnabled(FeatureFlags.SUPPORT_ABILITIES) &&
+      signer.type !== "read-only"
+    ) {
       await this.abilitiesService.deleteAbilitiesForAccount(address)
     }
     // remove dApp premissions

--- a/background/main.ts
+++ b/background/main.ts
@@ -163,6 +163,7 @@ import {
   addAccount,
   deleteAccount as deleteAccountFilter,
   deleteAbilitiesForAccount,
+  initAbilities,
 } from "./redux-slices/abilities"
 
 // This sanitizer runs on store and action data before serializing for remote
@@ -1535,6 +1536,9 @@ export default class Main extends BaseService<never> {
   }
 
   connectAbilitiesService(): void {
+    this.abilitiesService.emitter.on("initAbilities", (address) => {
+      this.store.dispatch(initAbilities(address))
+    })
     this.abilitiesService.emitter.on("newAbilities", (newAbilities) => {
       this.store.dispatch(addAbilities(newAbilities))
     })
@@ -1611,6 +1615,10 @@ export default class Main extends BaseService<never> {
       logger.info("Error looking up Ethereum address: ", error)
       return undefined
     }
+  }
+
+  async pollForAbilities(address: NormalizedEVMAddress): Promise<void> {
+    return this.abilitiesService.pollForAbilities(address)
   }
 
   async markAbilityAsCompleted(

--- a/background/redux-slices/abilities.ts
+++ b/background/redux-slices/abilities.ts
@@ -1,7 +1,25 @@
 import { createSlice } from "@reduxjs/toolkit"
 import { Ability, ABILITY_TYPES_ENABLED } from "../abilities"
 import { HexString, NormalizedEVMAddress } from "../types"
+import { KeyringsState } from "./keyrings"
+import { LedgerState } from "./ledger"
 import { createBackgroundAsyncThunk } from "./utils"
+
+const isLedgerAccount = (
+  ledger: LedgerState,
+  address: NormalizedEVMAddress
+): boolean =>
+  Object.values(ledger.devices)
+    .flatMap((device) =>
+      Object.values(device.accounts).flatMap((account) => account.address ?? "")
+    )
+    .includes(address)
+
+const isImportOrInternalAccount = (
+  keyrings: KeyringsState,
+  address: NormalizedEVMAddress
+): boolean =>
+  keyrings.keyrings.flatMap(({ addresses }) => addresses).includes(address)
 
 export type State = "open" | "completed" | "expired" | "deleted" | "all"
 
@@ -142,6 +160,23 @@ export const reportAndRemoveAbility = createBackgroundAsyncThunk(
     { extra: { main } }
   ) => {
     await main.reportAndRemoveAbility(address, abilitySlug, abilityId, reason)
+  }
+)
+
+export const initAbilities = createBackgroundAsyncThunk(
+  "abilities/initAbilities",
+  async (address: NormalizedEVMAddress, { getState, extra: { main } }) => {
+    const { ledger, keyrings } = getState() as {
+      ledger: LedgerState
+      keyrings: KeyringsState
+    }
+
+    if (
+      isImportOrInternalAccount(keyrings, address) ||
+      isLedgerAccount(ledger, address)
+    ) {
+      await main.pollForAbilities(address)
+    }
   }
 )
 

--- a/background/redux-slices/keyrings.ts
+++ b/background/redux-slices/keyrings.ts
@@ -10,7 +10,7 @@ type KeyringToVerify = {
   mnemonic: string[]
 } | null
 
-type KeyringsState = {
+export type KeyringsState = {
   keyrings: Keyring[]
   keyringMetadata: {
     [keyringId: string]: KeyringMetadata

--- a/background/services/abilities/index.ts
+++ b/background/services/abilities/index.ts
@@ -76,6 +76,7 @@ interface Events extends ServiceLifecycleEvents {
   updatedAbility: Ability
   newAccount: string
   deleteAccount: string
+  initAbilities: NormalizedEVMAddress
 }
 export default class AbilitiesService extends BaseService<Events> {
   constructor(
@@ -105,7 +106,6 @@ export default class AbilitiesService extends BaseService<Events> {
 
   protected override async internalStartService(): Promise<void> {
     await super.internalStartService()
-    //
     this.chainService.emitter.on(
       "newAccountToTrack",
       ({ addressOnNetwork, source }) => {
@@ -174,8 +174,7 @@ export default class AbilitiesService extends BaseService<Events> {
     // 1-by-1 decreases likelihood of hitting rate limit
     // eslint-disable-next-line no-restricted-syntax
     for (const address of addresses) {
-      // eslint-disable-next-line no-await-in-loop
-      await this.pollForAbilities(address)
+      this.emitter.emit("initAbilities", address as NormalizedEVMAddress)
     }
   }
 

--- a/background/services/abilities/index.ts
+++ b/background/services/abilities/index.ts
@@ -105,11 +105,17 @@ export default class AbilitiesService extends BaseService<Events> {
 
   protected override async internalStartService(): Promise<void> {
     await super.internalStartService()
-    this.chainService.emitter.on("newAccountToTrack", (addressOnNetwork) => {
-      const { address } = addressOnNetwork
-      this.pollForAbilities(address)
-      this.emitter.emit("newAccount", address)
-    })
+    //
+    this.chainService.emitter.on(
+      "newAccountToTrack",
+      ({ addressOnNetwork, source }) => {
+        if (source) {
+          const { address } = addressOnNetwork
+          this.pollForAbilities(address)
+          this.emitter.emit("newAccount", address)
+        }
+      }
+    )
   }
 
   async pollForAbilities(address: HexString): Promise<void> {

--- a/background/services/doggo/index.ts
+++ b/background/services/doggo/index.ts
@@ -77,9 +77,12 @@ export default class DoggoService extends BaseService<Events> {
 
       // Track referrals for all added accounts and any new ones that are added
       // after load.
-      this.chainService.emitter.on("newAccountToTrack", (addressOnNetwork) => {
-        this.trackReferrals(addressOnNetwork)
-      })
+      this.chainService.emitter.on(
+        "newAccountToTrack",
+        ({ addressOnNetwork }) => {
+          this.trackReferrals(addressOnNetwork)
+        }
+      )
       ;(await this.chainService.getAccountsToTrack()).forEach(
         (addressOnNetwork) => {
           this.trackReferrals(addressOnNetwork)

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -432,7 +432,7 @@ export default class IndexingService extends BaseService<Events> {
 
     this.chainService.emitter.on(
       "newAccountToTrack",
-      async (addressOnNetwork) => {
+      async ({ addressOnNetwork }) => {
         // whenever a new account is added, get token balances from Alchemy's
         // default list and add any non-zero tokens to the tracking list
         const balances = await this.retrieveTokenBalances(addressOnNetwork)

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -135,13 +135,20 @@ export default class NameService extends BaseService<Events> {
       }
     )
 
-    chainService.emitter.on("newAccountToTrack", async (addressOnNetwork) => {
-      try {
-        await this.lookUpName(addressOnNetwork)
-      } catch (error) {
-        logger.error("Error fetching name for address", addressOnNetwork, error)
+    chainService.emitter.on(
+      "newAccountToTrack",
+      async ({ addressOnNetwork }) => {
+        try {
+          await this.lookUpName(addressOnNetwork)
+        } catch (error) {
+          logger.error(
+            "Error fetching name for address",
+            addressOnNetwork,
+            error
+          )
+        }
       }
-    })
+    )
     this.emitter.on("resolvedName", async ({ from: { addressOnNetwork } }) => {
       try {
         const avatar = await this.lookUpAvatar(addressOnNetwork)

--- a/background/services/nfts/index.ts
+++ b/background/services/nfts/index.ts
@@ -85,7 +85,7 @@ export default class NFTsService extends BaseService<Events> {
 
     this.chainService.emitter.on(
       "newAccountToTrack",
-      async (addressOnNetwork) => {
+      async ({ addressOnNetwork }) => {
         this.emitter.emit("isReloadingNFTs", true)
         await this.initializeCollections([addressOnNetwork])
         this.emitter.emit("isReloadingNFTs", false)

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -823,7 +823,9 @@
       },
       "abilityStateTitle": "Show",
       "abilitiesTypesTitle": "Notify me about abilities type",
-      "accountsTitle": "Show/hide accounts"
+      "accountsTitle": "Show/hide accounts",
+      "accountsReadOnlyInfo": "Read-only accounts can’t see abilities. If you can, we recommend you import the address you want o see abilities for.",
+      "noAccounts": "No accounts"
     }
   },
   "globalError": {

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -824,7 +824,7 @@
       "abilityStateTitle": "Show",
       "abilitiesTypesTitle": "Notify me about abilities type",
       "accountsTitle": "Show/hide accounts",
-      "accountsReadOnlyInfo": "Read-only accounts can’t see abilities. If you can, we recommend you import the address you want o see abilities for.",
+      "accountsReadOnlyInfo": "Read-only accounts can’t see abilities. If you can, we recommend you import the address you want to see abilities for.",
       "noAccounts": "No accounts"
     }
   },

--- a/ui/components/Overview/AbilitiesHeader.tsx
+++ b/ui/components/Overview/AbilitiesHeader.tsx
@@ -100,6 +100,7 @@ export default function AbilitiesHeader(): ReactElement {
           padding: 12px 16px 12px 12px;
           width: 100%;
           box-sizing: border-box;
+          margin-bottom: 16px;
         }
 
         .abilities_header.init_state {

--- a/ui/pages/Abilities/AbilityFilter.tsx
+++ b/ui/pages/Abilities/AbilityFilter.tsx
@@ -138,19 +138,21 @@ export default function AbilityFilter(): ReactElement {
         <div className="simple_text">
           <span className="filter_title">{t("accountsTitle")}</span>
           <div className="filter_list">
-            {filteredAccountTotals.length > 0
-              ? filteredAccountTotals.map(({ address, name, avatarURL }) => (
-                  <SharedToggleItem
-                    key={address}
-                    label={name || address}
-                    thumbnailURL={avatarURL}
-                    checked={accounts.includes(address)}
-                    onChange={(toggleValue) =>
-                      handleUpdateAccount(address, toggleValue)
-                    }
-                  />
-                ))
-              : t("noAccounts")}
+            {filteredAccountTotals.length > 0 ? (
+              filteredAccountTotals.map(({ address, name, avatarURL }) => (
+                <SharedToggleItem
+                  key={address}
+                  label={name || address}
+                  thumbnailURL={avatarURL}
+                  checked={accounts.includes(address)}
+                  onChange={(toggleValue) =>
+                    handleUpdateAccount(address, toggleValue)
+                  }
+                />
+              ))
+            ) : (
+              <span className="no_accounts">{t("noAccounts")}</span>
+            )}
           </div>
         </div>
         <span className="accounts_info">
@@ -190,6 +192,10 @@ export default function AbilityFilter(): ReactElement {
           font-size: 14px;
           line-height: 16px;
           letter-spacing: 0.03em;
+        }
+        .no_accounts {
+          font-size: 18px;
+          color: var(--green-20);
         }
       `}</style>
     </SharedSlideUpMenuPanel>

--- a/ui/pages/Abilities/AbilityFilter.tsx
+++ b/ui/pages/Abilities/AbilityFilter.tsx
@@ -7,6 +7,7 @@ import {
   addAccount,
   deleteAccount,
 } from "@tallyho/tally-background/redux-slices/abilities"
+import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
 import {
   selectAbilityFilterAccounts,
   selectAbilityFilterState,
@@ -15,6 +16,7 @@ import {
 } from "@tallyho/tally-background/redux-slices/selectors"
 import React, { ReactElement, useCallback } from "react"
 import { useTranslation } from "react-i18next"
+import SharedIcon from "../../components/Shared/SharedIcon"
 import SharedRadio from "../../components/Shared/SharedRadio"
 import SharedSlideUpMenuPanel from "../../components/Shared/SharedSlideUpMenuPanel"
 import SharedToggleItem from "../../components/Shared/SharedToggleItem"
@@ -69,6 +71,9 @@ export default function AbilityFilter(): ReactElement {
   const types = useBackgroundSelector(selectAbilityFilterTypes)
   const accounts = useBackgroundSelector(selectAbilityFilterAccounts)
   const accountTotals = useBackgroundSelector(selectAccountTotals)
+  const filteredAccountTotals = accountTotals.filter(
+    ({ accountType }) => accountType !== AccountType.ReadOnly
+  )
   const dispatch = useBackgroundDispatch()
 
   const handleUpdateState = useCallback(
@@ -133,19 +138,30 @@ export default function AbilityFilter(): ReactElement {
         <div className="simple_text">
           <span className="filter_title">{t("accountsTitle")}</span>
           <div className="filter_list">
-            {accountTotals.map(({ address, name, avatarURL }) => (
-              <SharedToggleItem
-                key={address}
-                label={name || address}
-                thumbnailURL={avatarURL}
-                checked={accounts.includes(address)}
-                onChange={(toggleValue) =>
-                  handleUpdateAccount(address, toggleValue)
-                }
-              />
-            ))}
+            {filteredAccountTotals.length > 0
+              ? filteredAccountTotals.map(({ address, name, avatarURL }) => (
+                  <SharedToggleItem
+                    key={address}
+                    label={name || address}
+                    thumbnailURL={avatarURL}
+                    checked={accounts.includes(address)}
+                    onChange={(toggleValue) =>
+                      handleUpdateAccount(address, toggleValue)
+                    }
+                  />
+                ))
+              : t("noAccounts")}
           </div>
         </div>
+        <span className="accounts_info">
+          <SharedIcon
+            width={24}
+            color="var(--link)"
+            icon="icons/m/notif-announcement.svg"
+            customStyles="flex-shrink:0; margin-right: 18px;"
+          />
+          <span>{t("accountsReadOnlyInfo")}</span>
+        </span>
       </div>
       <style jsx>{`
         .filter {
@@ -165,6 +181,15 @@ export default function AbilityFilter(): ReactElement {
           display: inline-block;
           margin-bottom: 8px;
           width: 100%;
+        }
+        .accounts_info {
+          display: flex;
+          margin: 0 16px 0 4px;
+          color: var(--green-20);
+          font-weight: 500;
+          font-size: 14px;
+          line-height: 16px;
+          letter-spacing: 0.03em;
         }
       `}</style>
     </SharedSlideUpMenuPanel>


### PR DESCRIPTION
Closes #2978

This PR changes visibility for abilities. Abilities should not be shown for read-only accounts.

## UI
![Screenshot 2023-02-06 at 08 52 11](https://user-images.githubusercontent.com/23117945/216915295-a28cef12-3d82-4c16-bc21-f07c9d69b58a.png)


![Screenshot 2023-02-03 at 14 05 39](https://user-images.githubusercontent.com/23117945/216613462-3fd95c61-683d-4d4e-baa1-41f23b07aa4b.png)

## To Test
- [ ] check if abilities are not shown for read-only accounts
- [ ] check if abilities are fetched only for the correct accounts

## Testing Env
```
SUPPORT_ABILITIES=true
```

Latest build: [extension-builds-2981](https://github.com/tallyhowallet/extension/suites/10806567227/artifacts/543588141) (as of Mon, 06 Feb 2023 15:30:44 GMT).