### PR TITLE
Wallet Connect - Fix network switching

### DIFF
--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -344,6 +344,8 @@ export default class InternalEthereumProviderService extends BaseService<Events>
           return null
         }
 
+        logger.error("Unrecognized chain ID", newChainId)
+
         throw new EIP1193Error(EIP1193_ERROR_CODES.chainDisconnected)
       }
       case "metamask_getProviderState": // --- important MM only methods ---

--- a/background/services/wallet-connect/eip155-request-utils.ts
+++ b/background/services/wallet-connect/eip155-request-utils.ts
@@ -44,6 +44,7 @@ export function approveEIP155Request(
     case "personal_sign":
     case "eth_signTransaction":
     case "eth_sendTransaction":
+    case "wallet_switchEthereumChain":
       return formatJsonRpcResult(id, signedMessage)
 
     default:
@@ -72,6 +73,7 @@ export function processRequestParams(
     case "personal_sign":
     case "eth_sendTransaction":
     case "eth_signTransaction":
+    case "wallet_switchEthereumChain":
       return {
         id,
         topic,


### PR DESCRIPTION
Closes #2948 

Although the wallet can handle `wallet_switchEthereumChain` events, an additional action with the Wallet Connect client is required for the connected dApp to successfully recognize the network change

## Testing Env

```
SUPPORT_WALLET_CONNECT=true
```

## To Test
- [ ] Head to https://app.uniswap.org/#/swap
- [ ] Connect using Wallet Connect, then try to switch networks through the dApp