### PR TITLE
Update Avalanche token list

### DIFF
--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -299,7 +299,7 @@ export class PreferenceDatabase extends Dexie {
           )
 
           urls.push(
-            "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/mc.tokenlist.json"
+            "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/1722d8c47a728a64c8dca8ac160b32cf39c5e671/mc.tokenlist.json"
           )
 
           Object.assign(storedPreferences.tokenLists, { urls })

--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -287,6 +287,25 @@ export class PreferenceDatabase extends Dexie {
         })
     })
 
+    this.version(15).upgrade((tx) => {
+      return tx
+        .table("preferences")
+        .toCollection()
+        .modify((storedPreferences: Preferences) => {
+          const urls = storedPreferences.tokenLists.urls.filter(
+            (url) =>
+              url !==
+              "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/avalanche.tokenlist.json"
+          )
+
+          urls.push(
+            "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/mc.tokenlist.json"
+          )
+
+          Object.assign(storedPreferences.tokenLists, { urls })
+        })
+    })
+
     // This is the old version for populate
     // https://dexie.org/docs/Dexie/Dexie.on.populate-(old-version)
     // The this does not behave according the new docs, but works

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -18,7 +18,7 @@ const defaultPreferences: Preferences = {
       "https://api-polygon-tokens.polygon.technology/tokenlists/default.tokenlist.json", // Polygon Default Tokens
       "https://static.optimism.io/optimism.tokenlist.json", // Optimism Default Tokens
       "https://bridge.arbitrum.io/token-list-42161.json", // Arbitrum Default tokens
-      "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/avalanche.tokenlist.json", // Trader Joe tokens
+      "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/mc.tokenlist.json", // Trader Joe tokens
       "https://tokens.pancakeswap.finance/pancakeswap-default.json", // PancakeSwap Default List
     ],
   },

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -18,7 +18,7 @@ const defaultPreferences: Preferences = {
       "https://api-polygon-tokens.polygon.technology/tokenlists/default.tokenlist.json", // Polygon Default Tokens
       "https://static.optimism.io/optimism.tokenlist.json", // Optimism Default Tokens
       "https://bridge.arbitrum.io/token-list-42161.json", // Arbitrum Default tokens
-      "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/main/mc.tokenlist.json", // Trader Joe tokens
+      "https://raw.githubusercontent.com/traderjoe-xyz/joe-tokenlists/1722d8c47a728a64c8dca8ac160b32cf39c5e671/mc.tokenlist.json", // Trader Joe tokens
       "https://tokens.pancakeswap.finance/pancakeswap-default.json", // PancakeSwap Default List
     ],
   },


### PR DESCRIPTION
Closes #2988 
Related #2932 

This PR updates the default token list for Avalanche.

## To Test: 
- [ ] Reinstall the extension and import an account and choose  Avalanche network

Latest build: [extension-builds-2992](https://github.com/tallyhowallet/extension/suites/10805759394/artifacts/543533728) (as of Mon, 06 Feb 2023 15:00:07 GMT).