### PR TITLE
Optimistically dismiss Analytics notification

### DIFF
--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -86,6 +86,7 @@ const uiSlice = createSlice({
       settings: {
         ...state.settings,
         collectAnalytics,
+        showAnalyticsNotification: false,
       },
     }),
     setShowAnalyticsNotification: (


### PR DESCRIPTION
Closes #2993 

### To Test
- [ ] Reinstall extension
- [ ] Import an account
- [ ] Disable analytics through the settings menu
- [ ] Observe lack of analytics notification on the `Wallet` tab.

Latest build: [extension-builds-2994](https://github.com/tallyhowallet/extension/suites/10815479292/artifacts/544240159) (as of Mon, 06 Feb 2023 22:40:52 GMT).