### PR TITLE
Add custom chart color for Rootstock

### DIFF
--- a/ui/components/Overview/NetworksChart.tsx
+++ b/ui/components/Overview/NetworksChart.tsx
@@ -6,6 +6,7 @@ import {
   NETWORK_BY_CHAIN_ID,
   POLYGON,
   BINANCE_SMART_CHAIN,
+  ROOTSTOCK,
 } from "@tallyho/tally-background/constants"
 import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import { AccountTotalList } from "@tallyho/tally-background/redux-slices/selectors"
@@ -20,6 +21,7 @@ const NETWORKS_CHART_COLORS = {
   [OPTIMISM.chainID]: "#CD041C",
   [AVALANCHE.chainID]: "#E84142",
   [BINANCE_SMART_CHAIN.chainID]: "#F3BA2F",
+  [ROOTSTOCK.chainID]: "#F18C30",
 }
 
 const getNetworksPercents = (


### PR DESCRIPTION
### What
Make all built-in chains have a color 🎨 

![image](https://user-images.githubusercontent.com/20949277/217221494-e3b9e2a2-a5aa-4f72-8269-231336e0abcb.png)

Latest build: [extension-builds-2997](https://github.com/tallyhowallet/extension/suites/10837469077/artifacts/545848308) (as of Tue, 07 Feb 2023 19:23:53 GMT).