### PR TITLE
UI updates for Abilities header

### DIFF
--- a/ui/components/Overview/AbilitiesHeader.tsx
+++ b/ui/components/Overview/AbilitiesHeader.tsx
@@ -32,11 +32,22 @@ export default function AbilitiesHeader(): ReactElement {
     history.push("abilities")
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter") {
+      handleClick()
+    }
+  }
+
   return (
     <div
       className={classNames("abilities_header", {
         init_state: !hideDescription,
+        pointer: hideDescription,
       })}
+      tabIndex={0}
+      role="button"
+      onClick={hideDescription ? handleClick : undefined}
+      onKeyDown={hideDescription ? handleKeyDown : undefined}
     >
       <div className="info_container">
         <div className="abilities_info">
@@ -49,19 +60,7 @@ export default function AbilitiesHeader(): ReactElement {
             {t("header")}
           </div>
         </div>
-        <div
-          tabIndex={0}
-          role="button"
-          className="ability_count"
-          onClick={() => handleClick()}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              handleClick()
-            }
-          }}
-        >
-          {abilityCount}
-        </div>
+        <div className="ability_count">{abilityCount}</div>
       </div>
       {!hideDescription && (
         <div>
@@ -100,7 +99,7 @@ export default function AbilitiesHeader(): ReactElement {
           padding: 12px 16px 12px 12px;
           width: 100%;
           box-sizing: border-box;
-          margin-bottom: 16px;
+          margin-bottom: 24px;
         }
 
         .abilities_header.init_state {
@@ -112,7 +111,9 @@ export default function AbilitiesHeader(): ReactElement {
           box-shadow: 0px 16px 16px rgba(7, 17, 17, 0.3),
             0px 6px 8px rgba(7, 17, 17, 0.24), 0px 2px 4px rgba(7, 17, 17, 0.34);
         }
-
+        .abilities_header.pointer {
+          cursor: pointer;
+        }
         .abilities_info {
           display: flex;
           flex-direction: row;
@@ -137,7 +138,6 @@ export default function AbilitiesHeader(): ReactElement {
           background: var(--hunter-green);
           border-radius: 17px;
           padding: 0px 8px;
-          cursor: pointer;
           height: 24px;
 
           font-weight: 500;


### PR DESCRIPTION
This PR adds improvements for the Abilities Header. Changes:

* Increase margin-bottom of the banner to 24px
* Make the entire banner clickable (not just "none")

## UI
![Screenshot 2023-02-07 at 13 09 45](https://user-images.githubusercontent.com/23117945/217241279-18c82467-774f-4e79-bb1b-0b5110193a08.png)

## To Test
- [ ] Check the margin-bottom of the banner
- [ ] Check if the entire banner is clickable. On the first contact with the banner, only the button should be clickable.

## Testing Env
```
SUPPORT_ABILITIES=true
```