### PR TITLE
Add rarity rankings to NFTs

### DIFF
--- a/background/lib/poap_update.ts
+++ b/background/lib/poap_update.ts
@@ -61,6 +61,7 @@ function poapNFTModelToNFT(original: PoapNFTModel, owner: string): NFT {
     network: ETHEREUM,
     supply,
     isBadge: true,
+    rarity: {}, // no rarity rankings for POAPs
   }
 }
 

--- a/background/lib/simple-hash_update.ts
+++ b/background/lib/simple-hash_update.ts
@@ -39,6 +39,11 @@ type SimpleHashNFTModel = {
     }[]
   }
   owners: { owner_address: string; last_acquired_date: string }[]
+  rarity?: {
+    rank: number | null
+    score: number | null
+    unique_attributes: number | null
+  }
   extra_metadata: {
     attributes?: [{ trait_type?: string | null; value?: string | null }]
   }
@@ -170,6 +175,7 @@ function simpleHashNFTModelToNFT(
     external_url: nftURL = "",
     collection: { collection_id: collectionID },
     extra_metadata: metadata,
+    rarity,
   } = original
 
   const thumbnailURL =
@@ -212,6 +218,11 @@ function simpleHashNFTModelToNFT(
     collectionID,
     contract: contractAddress,
     owner,
+    rarity: {
+      rank: rarity?.rank ?? undefined,
+      score: rarity?.score ?? undefined,
+      uniqueAttributes: rarity?.unique_attributes ?? undefined,
+    },
     network: NETWORK_BY_CHAIN_ID[chainID],
     isBadge: isGalxeAchievement(nftURL),
   }

--- a/background/nfts.ts
+++ b/background/nfts.ts
@@ -51,6 +51,11 @@ export type NFT = {
   previewURL?: string
   transferDate?: string
   attributes: { trait: string; value: string }[]
+  rarity: {
+    rank?: number
+    score?: number
+    uniqueAttributes?: number
+  }
   contract: string
   owner: string
   network: EVMNetwork

--- a/background/redux-slices/nfts_update.ts
+++ b/background/redux-slices/nfts_update.ts
@@ -8,7 +8,8 @@ import { createBackgroundAsyncThunk } from "./utils"
 
 export type NFTCached = {
   chainID: string
-} & Omit<NFT, "network">
+  rarityRank: number | null
+} & Omit<NFT, "network" | "rarity">
 
 export type NFTCollectionCached = {
   floorPrice?: {
@@ -159,11 +160,12 @@ export function updateFilters(
 
 export function parseNFTs(nfts: NFT[]): NFTCached[] {
   return nfts.map((nft) => {
-    const { network, ...cached } = nft
+    const { network, rarity, ...cached } = nft
 
     return {
       ...cached,
       chainID: network.chainID,
+      rarityRank: rarity.rank ?? null,
     }
   })
 }

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -255,7 +255,8 @@
       "creator": "Creator",
       "properties": "Properties",
       "refresh": "Refresh metadata",
-      "rank": "Rank"
+      "rank": "Rank",
+      "rarityRank": "Rarity rank"
     },
     "units": {
       "nft_one": "NFT",

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -254,7 +254,8 @@
       "itemsCount": "Items in collection",
       "creator": "Creator",
       "properties": "Properties",
-      "refresh": "Refresh metadata"
+      "refresh": "Refresh metadata",
+      "rank": "Rank"
     },
     "units": {
       "nft_one": "NFT",

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -46,6 +46,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
     attributes,
     supply,
     isBadge,
+    rarityRank,
   } = nft
   const { totalNftCount, id: collectionID } = collection
   const network = NETWORK_BY_CHAIN_ID[chainID]
@@ -129,16 +130,25 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
         </div>
 
         <div className="preview_header">
-          <h1 className="ellipsis_multiline">{name || t("noTitle")}</h1>
-          {isEnabled(FeatureFlags.SUPPORT_NFT_SEND) && (
-            <SharedButton
-              type="tertiary"
-              size="small"
-              iconSmall="send"
-              iconPosition="left"
-            >
-              {t("preview.send")}
-            </SharedButton>
+          <div className="preview_section_row">
+            <h1 className="ellipsis_multiline">{name || t("noTitle")}</h1>
+            {isEnabled(FeatureFlags.SUPPORT_NFT_SEND) && (
+              <SharedButton
+                type="tertiary"
+                size="small"
+                iconSmall="send"
+                iconPosition="left"
+              >
+                {t("preview.send")}
+              </SharedButton>
+            )}
+          </div>
+
+          {rarityRank !== null && (
+            <span className="preview_rarity">
+              {t("preview.rank")}:
+              <span className="preview_rarity_rank"> {rarityRank}</span>
+            </span>
           )}
         </div>
 
@@ -274,8 +284,6 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
           line-height: 24px;
         }
         .preview_header {
-          display: flex;
-          justify-content: space-between;
           margin: 20px 24px;
         }
         .preview_header h1 {
@@ -346,6 +354,22 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
           margin-top: 8px;
           gap: 16px;
           justify-content: flex-start;
+        }
+        .preview_rarity {
+          display: inline-block;
+          background: var(--hunter-green);
+          border: 2px solid var(--green-40);
+          border-radius: 25px;
+          color: var(--green-40);
+          line-height: 24px;
+          font-size: 14px;
+          font-weight: 500;
+          padding: 2px 12px 0;
+          margin: 12px 0 14px;
+        }
+        .preview_rarity_rank {
+          color: var(--white);
+          font-size: 16px;
         }
         .no_shrink {
           flex-shrink: 0;

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -16,6 +16,7 @@ import { trimWithEllipsis } from "../../utils/textUtils"
 import SharedAddress from "../Shared/SharedAddress"
 import SharedButton from "../Shared/SharedButton"
 import SharedNetworkIcon from "../Shared/SharedNetworkIcon"
+import SharedTooltip from "../Shared/SharedTooltip"
 import ExploreMarketLink, { getRelevantMarketsList } from "./ExploreMarketLink"
 import NFTImage from "./NFTImage"
 
@@ -91,6 +92,9 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
     [collectionID, owner, network, dispatch]
   )
 
+  const localizedTotalCount = (totalNftCount ?? supply)?.toLocaleString()
+  const localizedRarityRank = rarityRank?.toLocaleString()
+
   return (
     <>
       <div className="preview_wrapper">
@@ -145,10 +149,26 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
           </div>
 
           {rarityRank !== null && (
-            <span className="preview_rarity">
-              {t("preview.rank")}:
-              <span className="preview_rarity_rank"> {rarityRank}</span>
-            </span>
+            <div className="preview_rarity_wrapper">
+              <SharedTooltip
+                height={37}
+                horizontalPosition="right"
+                IconComponent={() => (
+                  <span className="preview_rarity">
+                    {t("preview.rank")}:
+                    <span className="preview_rarity_rank">
+                      {" "}
+                      {localizedRarityRank}
+                    </span>
+                  </span>
+                )}
+              >
+                <div className="no_wrap">
+                  {t("preview.rarityRank")}: {localizedRarityRank} /{" "}
+                  {localizedTotalCount}
+                </div>
+              </SharedTooltip>
+            </div>
           )}
         </div>
 
@@ -188,7 +208,7 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
             <div className="preview_section_header">
               {t("preview.itemsCount")}
             </div>
-            <p>{totalNftCount ?? supply ?? "-"}</p>
+            <p>{localizedTotalCount ?? "-"}</p>
           </div>
           <div className="preview_section_column align_right">
             <div className="preview_section_header">{t("preview.creator")}</div>
@@ -355,6 +375,9 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
           gap: 16px;
           justify-content: flex-start;
         }
+        .preview_rarity_wrapper {
+          margin: 12px -8px 14px;
+        }
         .preview_rarity {
           display: inline-block;
           background: var(--hunter-green);
@@ -365,7 +388,6 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
           font-size: 14px;
           font-weight: 500;
           padding: 2px 12px 0;
-          margin: 12px 0 14px;
         }
         .preview_rarity_rank {
           color: var(--white);
@@ -373,6 +395,10 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
         }
         .no_shrink {
           flex-shrink: 0;
+        }
+        .no_wrap {
+          overflow: hidden;
+          white-space: nowrap;
         }
       `}</style>
     </>

--- a/ui/components/Shared/SharedSlideUpMenu.tsx
+++ b/ui/components/Shared/SharedSlideUpMenu.tsx
@@ -22,6 +22,7 @@ interface Props {
   size: SharedSlideUpMenuSize
   isFullScreen?: boolean
   isScrollable?: boolean
+  isDark?: boolean
   alwaysRenderChildren?: boolean
 }
 
@@ -40,6 +41,7 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
     children,
     customSize,
     isFullScreen,
+    isDark,
     isScrollable,
     alwaysRenderChildren,
   } = props
@@ -63,7 +65,7 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
       <div className={classNames("overlay", { closed: !isOpen })} />
       <div
         className={classNames("slide_up_menu", {
-          large: size === "large",
+          dark: isDark,
           closed: !isOpen,
         })}
         style={{ "--menu-height": menuHeight } as CSSProperties}
@@ -126,7 +128,7 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
             visiblity: hidden;
             pointer-events: none;
           }
-          .large {
+          .dark {
             background-color: var(--hunter-green);
           }
           .slide_up_menu.closed {

--- a/ui/components/Shared/SharedTooltip.tsx
+++ b/ui/components/Shared/SharedTooltip.tsx
@@ -7,7 +7,7 @@ type HorizontalPosition = "left" | "center" | "right"
 interface Props {
   verticalPosition?: VerticalPosition
   horizontalPosition?: HorizontalPosition
-  width: number
+  width?: number
   height?: number
   type?: "default" | "dark"
   isOpen?: boolean
@@ -105,7 +105,7 @@ export default function SharedTooltip(props: Props): ReactElement {
             display: block;
           }
           .tooltip {
-            width: ${width}px;
+            width: ${width !== undefined ? `${width}px` : "auto"};
             position: absolute;
             box-shadow: 0 2px 4px rgba(0, 20, 19, 0.24),
               0 6px 8px rgba(0, 20, 19, 0.14), 0 16px 16px rgba(0, 20, 19, 0.04);
@@ -118,7 +118,9 @@ export default function SharedTooltip(props: Props): ReactElement {
             padding: 12px;
             z-index: 20;
             ${getVerticalPosition(verticalPosition, height)}
-            ${getHorizontalPosition(horizontalPosition, width)}
+            ${width !== undefined
+              ? getHorizontalPosition(horizontalPosition, width)
+              : ""}
           }
           .dark {
             background: var(--green-120);

--- a/ui/components/Swap/SwapTransactionSettingsChooser.tsx
+++ b/ui/components/Swap/SwapTransactionSettingsChooser.tsx
@@ -88,6 +88,7 @@ export default function SwapTransactionSettingsChooser({
           <SharedSlideUpMenu
             isOpen={isSlideUpMenuOpen}
             size="large"
+            isDark
             close={() => {
               setIsSlideUpMenuOpen(false)
             }}

--- a/ui/pages/Claiming/Eligible.tsx
+++ b/ui/pages/Claiming/Eligible.tsx
@@ -131,6 +131,7 @@ export default function Eligible(): ReactElement {
         isOpen={showSuccessStep}
         close={handleSuccessModalClose}
         size="large"
+        isDark
       >
         <ClaimSuccessModalContent close={handleSuccessModalClose} />
       </SharedSlideUpMenu>

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -419,6 +419,7 @@ export default function Swap(): ReactElement {
             dispatch(clearSwapQuote())
           }}
           size="large"
+          isDark
         >
           {quote &&
             typeof sellAsset !== "undefined" &&


### PR DESCRIPTION
Resolves https://github.com/tallyhowallet/extension/issues/2991
### What
- Show rarity ranks on NFT preview

Other fixes:
- Fix color of slideup's background
- Allow tooltip to show content with "auto" width

![image](https://user-images.githubusercontent.com/20949277/217291504-4082f8f2-33f1-42a0-b0e5-107fff719906.png)

Note: in the tooltip we show `rank / # of NFTs in collection` which may be different from what OpenSea shows for some collections - if some ranks are shared by many NFT in the collection. As we don't have rarity data on the collection level we can't show this information.


### Testing env

```
SUPPORT_NFT_TAB=true
```


Latest build: [extension-builds-3000](https://github.com/tallyhowallet/extension/suites/10830021187/artifacts/545316928) (as of Tue, 07 Feb 2023 14:10:00 GMT).