### PR TITLE
Drop `beta` tag for Avalanche network.

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -462,7 +462,7 @@
     "testnet": "Test Network",
     "l2": "L2 scaling solution",
     "compatibleChain": "Ethereum-compatible blockchain",
-    "avalanche": "Mainnet C-Chain (beta)",
+    "avalanche": "Mainnet C-Chain",
     "connected": "Connected"
   },
   "readOnly": "Read-only",


### PR DESCRIPTION
### To Test
- [ ] Ensure that Avalanche does not display as `(beta)` in the network dropdown menu.

Latest build: [extension-builds-3004](https://github.com/tallyhowallet/extension/suites/10841982781/artifacts/546188235) (as of Tue, 07 Feb 2023 23:37:02 GMT).