### PR TITLE
Flip RPC request params

### DIFF
--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -25,7 +25,11 @@ import {
 import showExtensionPopup from "./show-popup"
 import { HexString } from "../../types"
 import { WEBSITE_ORIGIN } from "../../constants/website"
-import { handleRPCErrorResponse, PermissionMap } from "./utils"
+import {
+  handleRPCErrorResponse,
+  parseRPCRequestParams,
+  PermissionMap,
+} from "./utils"
 import { toHexChainID } from "../../networks"
 import { TALLY_INTERNAL_ORIGIN } from "../internal-ethereum-provider/constants"
 
@@ -431,9 +435,11 @@ export default class ProviderBridgeService extends BaseService<Events> {
   async routeContentScriptRPCRequest(
     enablingPermission: PermissionRequest,
     method: string,
-    params: RPCRequest["params"],
+    rawParams: RPCRequest["params"],
     origin: string
   ): Promise<unknown> {
+    const params = parseRPCRequestParams(enablingPermission, method, rawParams)
+
     try {
       switch (method) {
         case "eth_requestAccounts":


### PR DESCRIPTION
Resolves https://github.com/tallyhowallet/extension/issues/2985
### What

Check if wallet address is on the expected position in params list for `eth_call` and `personal_sign` methods.  If it isn't then flip params order.

This should allow dapps that are not following JSON-RPC standard to be able to sign messages anyway.

### Testing
Check if you can connect to dapp and sign message on:
- https://www.premint.xyz/
- https://mintkudos.xyz/
- https://login.xyz/
- https://tallyho.org/web3pledge/

Latest build: [extension-builds-3006](https://github.com/tallyhowallet/extension/suites/10852469412/artifacts/546985369) (as of Wed, 08 Feb 2023 11:39:07 GMT).