### PR TITLE
No change filter state after reloading

### DIFF
--- a/background/redux-slices/abilities.ts
+++ b/background/redux-slices/abilities.ts
@@ -49,15 +49,6 @@ const initialState: AbilitiesState = {
   hideDescription: false,
 }
 
-const isInitialState = (state: AbilitiesState): boolean =>
-  state.filter.state === initialState.filter.state &&
-  state.filter.types.every(
-    (type, idx) => type === initialState.filter.types[idx]
-  ) &&
-  state.filter.accounts.length === 0 &&
-  Object.keys(state.abilities).length === 0 &&
-  state.hideDescription === initialState.hideDescription
-
 const abilitiesSlice = createSlice({
   name: "abilities",
   initialState,
@@ -190,7 +181,7 @@ export const initAbilities = createBackgroundAsyncThunk(
       await main.pollForAbilities(address)
       // Accounts for filter should be enabled after the first initialization.
       // The state of the filters after each reload should not refresh.
-      if (isInitialState(abilities)) {
+      if (JSON.stringify(abilities) === JSON.stringify(initialState)) {
         dispatch(addAccount(address))
       }
     }

--- a/background/services/abilities/index.ts
+++ b/background/services/abilities/index.ts
@@ -178,6 +178,9 @@ export default class AbilitiesService extends BaseService<Events> {
   }
 
   async abilitiesAlarm(): Promise<void> {
+    if (!isEnabled(FeatureFlags.SUPPORT_ABILITIES)) {
+      return
+    }
     const accountsToTrack = await this.chainService.getAccountsToTrack()
     const addresses = new Set(accountsToTrack.map((account) => account.address))
 


### PR DESCRIPTION
This PR makes the filter state for abilities is not updated after reloading.  Accounts added after the flag change should be enabled.

## To Test

- [ ] Run the application when `SUPPORT_ABILITIES=false`. Add new accounts. Enable the feature flag. Go to the abilities page and check the filter. The accounts should be enabled.
- [ ] Change the state of the filter. Make some accounts disabled. Reload the script and check the state again. It should be the same as before reloading.

Latest build: [extension-builds-3008](https://github.com/tallyhowallet/extension/suites/10857046169/artifacts/547299870) (as of Wed, 08 Feb 2023 15:02:41 GMT).