### PR TITLE
Remove NFT collections with no NFTs from DOM

### DIFF
--- a/ui/components/NFTS_update/NFTCollection.tsx
+++ b/ui/components/NFTS_update/NFTCollection.tsx
@@ -112,6 +112,8 @@ export default function NFTCollection(props: {
 
   const onItemClick = (nft: NFTCached) => openPreview({ nft, collection })
 
+  if (!nftCount && !isLoading && wasUpdated) return <></>
+
   return (
     <>
       <div


### PR DESCRIPTION
### What

If there was a collection with no NFTs even after it was reloaded then it was hidden (no opacity or mouse events). Because it was still in the DOM it was messing up expanding collection animations. Let's remove that element from DOM after it fails to load any NFTs.

### Testing
- load an address with a collection with no NFTs (POAPs most likely as we always have this collection loaded even if it has no NFTs) and check how collections are expanding
- example: my nemesis `ensagent.eth` who holds `berry.eth` 😄 then on Wallet page try to expand ENS collection. It should expand to the right. 
![image](https://user-images.githubusercontent.com/20949277/217838025-17d54e5d-4c99-4372-9a41-3303e03625a4.png)


Latest build: [extension-builds-3011](https://github.com/tallyhowallet/extension/suites/10881502011/artifacts/549114381) (as of Thu, 09 Feb 2023 14:24:42 GMT).