### PR TITLE
Add Daylight API Key to daylight requests

### DIFF
--- a/background/lib/daylight.ts
+++ b/background/lib/daylight.ts
@@ -82,9 +82,14 @@ export const getDaylightAbilities = async (
   address: string
 ): Promise<DaylightAbility[]> => {
   try {
-    const response: AbilitiesResponse = await fetchJson(
-      `${DAYLIGHT_BASE_URL}/wallets/${address}/abilities?deadline=all`
-    )
+    const response: AbilitiesResponse = await fetchJson({
+      url: `${DAYLIGHT_BASE_URL}/wallets/${address}/abilities?deadline=all`,
+      ...(process.env.DAYLIGHT_API_KEY && {
+        headers: {
+          Authorization: `Bearer ${process.env.DAYLIGHT_API_KEY}`,
+        },
+      }),
+    })
 
     return response.abilities
   } catch (err) {


### PR DESCRIPTION
### To Test
- [x] Add the daylight api key to your `.env` file.
- [x] Import a wallet
- [x] In the network tab - observe a successful request happening with the correct `Authorization` header.

Confirmation that the key has been added to gh secrets:
<img width="707" alt="image" src="https://user-images.githubusercontent.com/94649004/218126186-401d96d7-b6e4-4d53-88c1-6a433f57f0d8.png">


Latest build: [extension-builds-3014](https://github.com/tallyhowallet/extension/suites/10906122700/artifacts/550931024) (as of Fri, 10 Feb 2023 14:59:35 GMT).