### PR TITLE
Retry up to five times if an addresses abilities are still pending

### DIFF
--- a/background/lib/daylight.ts
+++ b/background/lib/daylight.ts
@@ -3,6 +3,7 @@ import { AbilityType } from "../abilities"
 import logger from "./logger"
 
 const DAYLIGHT_BASE_URL = "https://api.daylight.xyz/v1"
+const DEFAULT_RETRIES = 5 // # of times to retry fetching abilities with "pending" status
 
 type Community = {
   chain: string
@@ -79,7 +80,10 @@ type SpamReportResponse = {
 }
 
 export const getDaylightAbilities = async (
-  address: string
+  address: string,
+  // Amount of times to retry fetching abilities for an address that is not fully synced yet.
+  // https://docs.daylight.xyz/reference/retrieve-wallets-abilities
+  retries = DEFAULT_RETRIES
 ): Promise<DaylightAbility[]> => {
   try {
     const response: AbilitiesResponse = await fetchJson({
@@ -90,6 +94,10 @@ export const getDaylightAbilities = async (
         },
       }),
     })
+
+    if (retries > 0 && response.status === "pending") {
+      return await getDaylightAbilities(address, retries - 1)
+    }
 
     return response.abilities
   } catch (err) {

--- a/background/lib/tests/daylight.unit.test.ts
+++ b/background/lib/tests/daylight.unit.test.ts
@@ -1,0 +1,25 @@
+// It's necessary to have an object w/ the function on it so we can use spyOn
+import * as ethers from "@ethersproject/web" // << THIS IS THE IMPORTANT TRICK
+import * as daylight from "../daylight"
+
+describe("Daylight", () => {
+  describe("getDaylightAbilities", () => {
+    it("Should retry the correct number of times if response status is 'pending' ", async () => {
+      const fetchJsonResponse = {
+        abilities: [],
+        status: "pending",
+      }
+
+      const spy = jest
+        .spyOn(ethers, "fetchJson")
+        .mockResolvedValue(fetchJsonResponse)
+
+      await daylight.getDaylightAbilities(
+        "0x208e94d5661a73360d9387d3ca169e5c130090cd",
+        5
+      )
+
+      expect(spy).toHaveBeenCalledTimes(6)
+    })
+  })
+})


### PR DESCRIPTION
This is a difficult one to test - so will probably need to rely on making sure code & test are accurate.

The way to test this would be:
- [ ] Import an address into the wallet that daylight has never seen - and has a large amount of abilities (probably not possible)
- [ ] If there are a large amount of abilities associated with the address - the response will resolve with N abilities and a status of "pending"
- [ ] Upon seeing the pending status - the app should fire more requests until it either sees a `synced` status or has reached 5 retries.

Latest build: [extension-builds-3015](https://github.com/tallyhowallet/extension/suites/10908416756/artifacts/551098481) (as of Fri, 10 Feb 2023 16:48:02 GMT).