### PR TITLE
Handle multiple banners on Wallet page

### DIFF
--- a/ui/components/Wallet/WalletAnalyticsNotificationBanner.tsx
+++ b/ui/components/Wallet/WalletAnalyticsNotificationBanner.tsx
@@ -26,12 +26,13 @@ export default function WalletAnalyticsNotificationBanner(): ReactElement {
         hide: !showNotification,
       })}
     >
-      <SharedBanner>
+      <SharedBanner customStyles="width: 100%; box-sizing: border-box;">
         <div className="content_container">
           <SharedIcon
             icon="icons/m/notif-correct.svg"
             width={24}
             color="var(--success)"
+            customStyles="flex-shrink:0;"
           />
           <div className="content">
             <h1>{t("wallet.analyticsNotification.title")}</h1>
@@ -54,14 +55,14 @@ export default function WalletAnalyticsNotificationBanner(): ReactElement {
             width={16}
             color="var(--green-40)"
             hoverColor="var(--green-20)"
+            customStyles="flex-shrink:0;"
           />
         </div>
       </SharedBanner>
       <style jsx>{`
         .container {
-          margin: 0 16px;
+          margin: 0 8px;
           max-height: 200px;
-          width: 352px;
           transition: all 500ms ease;
         }
         .container.hide {

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -10,6 +10,7 @@ import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import classNames from "classnames"
 import { useTranslation } from "react-i18next"
 import { NETWORKS_SUPPORTING_NFTS } from "@tallyho/tally-background/nfts"
+import { selectShowAnalyticsNotification } from "@tallyho/tally-background/redux-slices/ui"
 import { useBackgroundDispatch, useBackgroundSelector } from "../hooks"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
 import WalletAssetList from "../components/Wallet/WalletAssetList"
@@ -62,6 +63,10 @@ export default function Wallet(): ReactElement {
     (background) => background.ui?.initializationLoadingTimeExpired
   )
 
+  const showAnalyticsNotification = useBackgroundSelector(
+    selectShowAnalyticsNotification
+  )
+
   const panelNames = [t("wallet.pages.assets")]
 
   if (NETWORKS_SUPPORTING_NFTS.has(selectedNetwork.chainID)) {
@@ -73,7 +78,7 @@ export default function Wallet(): ReactElement {
   return (
     <>
       <div className="page_content">
-        <WalletToggleDefaultBanner />
+        {!showAnalyticsNotification && <WalletToggleDefaultBanner />}
         <WalletAnalyticsNotificationBanner />
         <div className="section">
           <WalletAccountBalanceControl


### PR DESCRIPTION
Close #3023 

Changes:

- set the correct width
- fix the width of icons (checkmark and X)
- display only one banner

<img width="379" alt="Screenshot 2023-02-13 at 16 40 48" src="https://user-images.githubusercontent.com/23117945/218503416-9ad584bb-7761-4b19-9e72-0b74b9fff9df.png">


Latest build: [extension-builds-3026](https://github.com/tallyhowallet/extension/suites/10948840013/artifacts/554047633) (as of Mon, 13 Feb 2023 15:46:30 GMT).