### PR TITLE
Fix issue for exporting logs

### DIFF
--- a/background/lib/logger.ts
+++ b/background/lib/logger.ts
@@ -293,9 +293,13 @@ export function serializeLogs(): string {
     logEntries
       // Only grab logs from the past hour
       .filter((logLine) => {
+        // There was a problem here with the format of the current date.
+        // The date for the log line was in ISO standard.
+        // Both dates should be created using the same standard.
+        const currentDate = new Date(Date.now() - HOUR).toISOString()
         return (
           new Date(logLine.substring(1, iso8601Length)) >
-          new Date(Date.now() - HOUR)
+          new Date(currentDate.slice(0, -1))
         )
       })
       // Sort by date.


### PR DESCRIPTION
Closes #2938 

This PR fixes the logs export issue. The dates compared were not in the same standard. The current date was created using local time. However, the log time was in ISO standard.

## To Test
- [ ] Go to the settings page and try exporting logs. 

Latest build: [extension-builds-3029](https://github.com/tallyhowallet/extension/suites/10966059766/artifacts/555325962) (as of Tue, 14 Feb 2023 09:15:52 GMT).