### PR TITLE
Hide untrusted tokens from tokens selector

### DIFF
--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -321,3 +321,23 @@ export function heuristicDesiredDecimalsForUnitPrice(
     minimumDesiredDecimals
   )
 }
+
+/**
+ * NB: non-base assets that don't have any token lists are considered
+ * untrusted. Reifying base assets clearly will improve this check down the
+ * road. Eventually, assets can be flagged as trusted by adding them to an
+ * "internal" token list that users can export and share.
+ *
+ */
+export function isUntrustedAsset(
+  asset: AnyAsset | undefined,
+  selectedNetwork: AnyNetwork
+): boolean {
+  if (asset) {
+    const numTokenLists = asset?.metadata?.tokenLists?.length ?? 0
+    const baseAsset = isBuiltInNetworkBaseAsset(asset, selectedNetwork)
+
+    return numTokenLists === 0 && !baseAsset
+  }
+  return false
+}

--- a/background/redux-slices/utils/tests/asset-utils.unit.test.ts
+++ b/background/redux-slices/utils/tests/asset-utils.unit.test.ts
@@ -1,0 +1,44 @@
+import { ETH, ETHEREUM } from "../../../constants"
+import { isUntrustedAsset } from "../asset-utils"
+
+describe("Asset utils", () => {
+  describe("isUntrustedAsset", () => {
+    test("should return true if is an untrusted asset", () => {
+      const asset = {
+        name: "Test",
+        symbol: "TST",
+        decimals: 18,
+        metadata: {
+          coinGeckoID: "test",
+          tokenLists: [],
+          websiteURL: "",
+        },
+      }
+      expect(isUntrustedAsset(asset, ETHEREUM)).toBeTruthy()
+    })
+    test("should return false if is a trusted asset", () => {
+      const asset = {
+        name: "Test",
+        symbol: "TST",
+        decimals: 18,
+        metadata: {
+          coinGeckoID: "test",
+          tokenLists: [
+            {
+              name: "",
+              url: "",
+            },
+          ],
+          websiteURL: "",
+        },
+      }
+      expect(isUntrustedAsset(asset, ETHEREUM)).toBeFalsy()
+    })
+    test("should return false if is a base asset", () => {
+      expect(isUntrustedAsset(ETH, ETHEREUM)).toBeFalsy()
+    })
+    test("should return false if an asset is undefined", () => {
+      expect(isUntrustedAsset(undefined, ETHEREUM)).toBeFalsy()
+    })
+  })
+})

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -19,6 +19,7 @@ import {
   NFTCollectionCached,
 } from "@tallyho/tally-background/redux-slices/nfts_update"
 import classNames from "classnames"
+import { isUntrustedAsset } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import SharedButton from "./SharedButton"
 import SharedSlideUpMenu from "./SharedSlideUpMenu"
 import SharedAssetItem, {
@@ -136,10 +137,14 @@ function SelectAssetMenuContent<T extends AnyAsset>(
   const [searchTerm, setSearchTerm] = useState("")
   const searchInput = useRef<HTMLInputElement | null>(null)
 
+  const trustedAssets = assets.filter(
+    ({ asset }) => !isUntrustedAsset(asset, currentNetwork)
+  )
+
   const filteredAssets =
     searchTerm.trim() === ""
-      ? assets
-      : assets.filter(({ asset }) => {
+      ? trustedAssets
+      : trustedAssets.filter(({ asset }) => {
           return (
             asset.symbol.toLowerCase().includes(searchTerm.toLowerCase()) ||
             ("contractAddress" in asset &&

--- a/ui/components/Shared/__tests__/SharedAssetInput.test.tsx
+++ b/ui/components/Shared/__tests__/SharedAssetInput.test.tsx
@@ -11,6 +11,16 @@ const asset: FungibleAsset = {
   symbol: "FAKE",
   name: "Fake token",
   decimals: 2,
+  metadata: {
+    coinGeckoID: "fake",
+    tokenLists: [
+      {
+        name: "",
+        url: "",
+      },
+    ],
+    websiteURL: "",
+  },
 }
 const assetsAndAmounts = [
   {
@@ -23,6 +33,30 @@ const assetsAndAmounts = [
       symbol: "TST",
       name: "Test token",
       decimals: 2,
+      metadata: {
+        coinGeckoID: "test",
+        tokenLists: [
+          {
+            name: "",
+            url: "",
+          },
+        ],
+        websiteURL: "",
+      },
+    },
+    amount: 300n,
+    localizedDecimalAmount: "3",
+  },
+  {
+    asset: {
+      symbol: "UTT",
+      name: "Untrusted token",
+      decimals: 2,
+      metadata: {
+        coinGeckoID: "test",
+        tokenLists: [],
+        websiteURL: "",
+      },
     },
     amount: 300n,
     localizedDecimalAmount: "3",
@@ -100,6 +134,22 @@ describe("SharedAssetInput", () => {
     expect(searchbox).toHaveValue("Fake")
     expect(ui.queryByText("Fake token")).toBeVisible()
     expect(ui.queryByText("Test token")).not.toBeInTheDocument()
+  })
+
+  test("should not allow to search for untrusted assets with a searchbox", async () => {
+    const ui = renderWithProviders(<SharedAssetInputWithState />)
+    const assetButton = ui.getByText("FAKE")
+
+    await userEvent.click(assetButton)
+    expect(ui.queryByText("Untrusted token")).not.toBeInTheDocument()
+
+    const searchbox = ui.getByPlaceholderText("Search by name or address")
+    expect(searchbox).toHaveValue("")
+
+    await userEvent.type(searchbox, "Untrusted")
+
+    expect(searchbox).toHaveValue("Untrusted")
+    expect(ui.queryByText("Untrusted token")).not.toBeInTheDocument()
   })
 
   test("should allow to select different asset", async () => {

--- a/ui/components/Wallet/AssetListItem/CommonAssetListItem.tsx
+++ b/ui/components/Wallet/AssetListItem/CommonAssetListItem.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom"
 import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 
 import { useTranslation } from "react-i18next"
-import { isBuiltInNetworkBaseAsset } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
+import { isUntrustedAsset } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
 import { NETWORKS_SUPPORTING_SWAPS } from "@tallyho/tally-background/constants"
 import SharedLoadingSpinner from "../../Shared/SharedLoadingSpinner"
@@ -36,22 +36,12 @@ export default function CommonAssetListItem(
     typeof assetAmount.localizedMainCurrencyAmount === "undefined"
   const selectedNetwork = useBackgroundSelector(selectCurrentNetwork)
 
-  // NB: non-base assets that don't have any token lists are considered
-  // untrusted. Reifying base assets clearly will improve this check down the
-  // road. Eventually, assets can be flagged as trusted by adding them to an
-  // "internal" token list that users can export and share.
-  const numTokenLists = assetAmount?.asset?.metadata?.tokenLists?.length ?? 0
-  const baseAsset = isBuiltInNetworkBaseAsset(
-    assetAmount?.asset,
-    selectedNetwork
-  )
-
   const contractAddress =
     "contractAddress" in assetAmount.asset
       ? assetAmount.asset.contractAddress
       : undefined
 
-  const assetIsUntrusted = numTokenLists === 0 && !baseAsset
+  const assetIsUntrusted = isUntrustedAsset(assetAmount?.asset, selectedNetwork)
 
   return (
     <Link


### PR DESCRIPTION
Close #2941 

This PR hides untrusted tokens from the swap list.

## UI

Before
![Screenshot 2023-02-15 at 08 52 16](https://user-images.githubusercontent.com/23117945/218967400-f4efab13-a6de-45ef-9cbd-f313cadc8f2a.png)

After
![Screenshot 2023-02-15 at 08 51 00](https://user-images.githubusercontent.com/23117945/218967383-cd8dd05f-3f69-4d01-a359-d6ce1e91e90c.png)

## To Test

- [ ] Go to the swap page and try to select the token.  Untrusted tokens should be hidden.

Latest build: [extension-builds-3033](https://github.com/tallyhowallet/extension/suites/10990796483/artifacts/557115793) (as of Wed, 15 Feb 2023 08:33:13 GMT).