### PR TITLE
Break asset name on single asset page

### DIFF
--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -189,9 +189,9 @@ export default function SingleAsset(): ReactElement {
             font-size: 22px;
             font-weight: 500;
             line-height: 32px;
-            text-align: center;
             text-transform: uppercase;
             margin-left: 8px;
+            word-break: break-word;
           }
           .asset_wrap {
             display: flex;
@@ -223,7 +223,7 @@ export default function SingleAsset(): ReactElement {
             width: 16px;
             height: 16px;
             background-color: var(--green-40);
-            margin-left: 5px;
+            margin: 0 5px;
           }
           .new_tab_link:hover .icon_new_tab {
             background-color: var(--trophy-gold);


### PR DESCRIPTION
Resolves https://github.com/tallyhowallet/extension/issues/3034

(couldn't find a good example but now it should be breaking the word)
![image](https://user-images.githubusercontent.com/20949277/219052178-7af807cb-53f6-4db8-85a5-9b3708824f7e.png)


Latest build: [extension-builds-3035](https://github.com/tallyhowallet/extension/suites/10998123811/artifacts/557629421) (as of Wed, 15 Feb 2023 14:20:49 GMT).