### PR TITLE
Use `erc20` argument when fetching token balances via Alchemy.

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -150,14 +150,11 @@ export async function getAssetTransfers(
  */
 export async function getTokenBalances(
   provider: SerialFallbackProvider,
-  { address, network }: AddressOnNetwork,
-  tokens?: HexString[]
+  { address, network }: AddressOnNetwork
 ): Promise<SmartContractAmount[]> {
-  const uniqueTokens = [...new Set(tokens ?? [])]
-
   const json: unknown = await provider.send("alchemy_getTokenBalances", [
     address,
-    uniqueTokens.length > 0 ? uniqueTokens : "DEFAULT_TOKENS",
+    "erc20",
   ])
 
   if (!isValidAlchemyTokenBalanceResponse(json)) {

--- a/background/services/chain/asset-data-helper.ts
+++ b/background/services/chain/asset-data-helper.ts
@@ -49,11 +49,7 @@ export default class AssetDataHelper {
 
     try {
       if (provider.supportsAlchemy) {
-        return await getAlchemyTokenBalances(
-          provider,
-          addressOnNetwork,
-          smartContractAddresses
-        )
+        return await getAlchemyTokenBalances(provider, addressOnNetwork)
       }
       return await getTokenBalances(
         addressOnNetwork,


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/94649004/219163055-14b516d4-7e88-4eaa-8590-fbe1d3b7b0c8.png)
![image](https://user-images.githubusercontent.com/94649004/219163111-bae1e959-19de-4d10-afe3-ad2f2cd829ce.png)


Due to the recent polygon hard-fork it is no longer possible to batch more than 100 requests together on polygon.  Because alchemy relies on batch calling under the hood when processing `alchemy_getTokenBalances` requests sent with a list of token contracts to check - we need to move away from the pattern of passing in a discrete lists of contracts to check.  

Luckily, Alchemy exposes the `erc20` request parameter which returns all erc20 balances for a given address - which we can use not only on polygon but on all chains alchemy supports - so lets do that!

### To Test
- [ ] Import a new wallet
- [ ] You should see token balances in the wallet - likely with both "trusted" and "untrusted" tokens.

Latest build: [extension-builds-3036](https://github.com/tallyhowallet/extension/suites/11007404854/artifacts/558317221) (as of Wed, 15 Feb 2023 21:13:48 GMT).