### PR TITLE
Fix issue for migration state

### DIFF
--- a/background/redux-slices/migrations/index.ts
+++ b/background/redux-slices/migrations/index.ts
@@ -21,6 +21,7 @@ import to21 from "./to-21"
 import to22 from "./to-22"
 import to23 from "./to-23"
 import to24 from "./to-24"
+import to25 from "./to-25"
 
 /**
  * The version of persisted Redux state the extension is expecting. Any previous
@@ -60,6 +61,7 @@ const allMigrations: { [targetVersion: string]: Migration } = {
   22: to22,
   23: to23,
   24: to24,
+  25: to25,
 }
 
 /**

--- a/background/redux-slices/migrations/to-25.ts
+++ b/background/redux-slices/migrations/to-25.ts
@@ -1,0 +1,6 @@
+// Missing migration due to incorrect version update from 23 to 25.
+export default (
+  prevState: Record<string, unknown>
+): Record<string, unknown> => {
+  return prevState
+}


### PR DESCRIPTION
This PR fixes the issue of the incorrect state of the redux version. The issue occurred during the [upgrade](https://github.com/tallyhowallet/extension/commit/9519333b28caeda423cf8c4e4bd0b705ddab4da0#diff-b230998d1b07555389be4903734ca40c413bb671181a92e55a3f2d9c7bc2df7aL28) from version 23 to 24. Changes add missing migration 25.


Latest build: [extension-builds-3049](https://github.com/tallyhowallet/extension/suites/11045816318/artifacts/561210209) (as of Fri, 17 Feb 2023 12:34:19 GMT).