### PR TITLE
Make claim type enabled by default

### DIFF
--- a/background/abilities.ts
+++ b/background/abilities.ts
@@ -25,11 +25,11 @@ export const ABILITY_TYPES_ENABLED = [
   "airdrop",
   "vote",
   "access",
+  "claim",
 ] as const
 // https://docs.daylight.xyz/reference/ability-model#ability-types
 export const ABILITY_TYPES = [
   ...ABILITY_TYPES_ENABLED,
-  "claim",
   "product",
   "event",
   "article",

--- a/background/redux-slices/migrations/index.ts
+++ b/background/redux-slices/migrations/index.ts
@@ -22,12 +22,13 @@ import to22 from "./to-22"
 import to23 from "./to-23"
 import to24 from "./to-24"
 import to25 from "./to-25"
+import to26 from "./to-26"
 
 /**
  * The version of persisted Redux state the extension is expecting. Any previous
  * state without this version, or with a lower version, ought to be migrated.
  */
-export const REDUX_STATE_VERSION = 25
+export const REDUX_STATE_VERSION = 26
 
 /**
  * Common type for all migration functions.
@@ -62,6 +63,7 @@ const allMigrations: { [targetVersion: string]: Migration } = {
   23: to23,
   24: to24,
   25: to25,
+  26: to26,
 }
 
 /**

--- a/background/redux-slices/migrations/to-26.ts
+++ b/background/redux-slices/migrations/to-26.ts
@@ -18,13 +18,17 @@ export default (
   const { abilities } = typedPrevState
   const { filter } = abilities
 
+  const types = filter.types.includes("claim")
+    ? filter.types
+    : [...filter.types, "claim"]
+
   return {
     ...prevState,
     abilities: {
       ...abilities,
       filter: {
         ...filter,
-        types: [...filter.types, "claim"],
+        types,
       },
     },
   }

--- a/background/redux-slices/migrations/to-26.ts
+++ b/background/redux-slices/migrations/to-26.ts
@@ -1,0 +1,31 @@
+type State = {
+  abilities: {
+    filter: { state: string; types: string[]; accounts: string[] }
+    abilities: {
+      [address: string]: {
+        [uuid: string]: unknown
+      }
+    }
+    hideDescription: boolean
+  }
+}
+
+export default (
+  prevState: Record<string, unknown>
+): Record<string, unknown> => {
+  const typedPrevState = prevState as State
+
+  const { abilities } = typedPrevState
+  const { filter } = abilities
+
+  return {
+    ...prevState,
+    abilities: {
+      ...abilities,
+      filter: {
+        ...filter,
+        types: [...filter.types, "claim"],
+      },
+    },
+  }
+}


### PR DESCRIPTION
Claim type for abilities should be enabled by default.

<img width="376" alt="Screenshot 2023-02-20 at 16 15 54" src="https://user-images.githubusercontent.com/23117945/220144601-2be0f086-8236-4652-b613-4be72e201add.png">

## To Test
- [ ] Install the extension. Import a new account and check the filter for abilities.  Claim type should be enabled by default.
- [ ] Make migration. The claim type should be enabled for existing users.

Latest build: [extension-builds-3059](https://github.com/tallyhowallet/extension/suites/11107052947/artifacts/565763395) (as of Tue, 21 Feb 2023 10:59:43 GMT).