### PR TITLE
Fix the issue of getting abilities

### DIFF
--- a/background/lib/daylight.ts
+++ b/background/lib/daylight.ts
@@ -79,6 +79,17 @@ type SpamReportResponse = {
   success: boolean
 }
 
+// More query params
+// https://docs.daylight.xyz/reference/get_v1-wallets-address-abilities
+const QUERY_PARAMS = {
+  // The most interesting abilities will be the first
+  sort: "magic",
+  sortDirection: "desc",
+  // The limit needs to be set. It is set to the highest value.
+  limit: "1000",
+  deadline: "all",
+}
+
 export const getDaylightAbilities = async (
   address: string,
   // Amount of times to retry fetching abilities for an address that is not fully synced yet.
@@ -86,8 +97,13 @@ export const getDaylightAbilities = async (
   retries = DEFAULT_RETRIES
 ): Promise<DaylightAbility[]> => {
   try {
+    const params = Object.entries(QUERY_PARAMS)
+      .reduce((result, [key, value]) => {
+        return result.concat("&", `${key}=${value}`)
+      }, "")
+      .substring(1)
     const response: AbilitiesResponse = await fetchJson({
-      url: `${DAYLIGHT_BASE_URL}/wallets/${address}/abilities?deadline=all`,
+      url: `${DAYLIGHT_BASE_URL}/wallets/${address}/abilities?${params}`,
       ...(process.env.DAYLIGHT_API_KEY && {
         headers: {
           Authorization: `Bearer ${process.env.DAYLIGHT_API_KEY}`,

--- a/background/lib/daylight.ts
+++ b/background/lib/daylight.ts
@@ -79,31 +79,26 @@ type SpamReportResponse = {
   success: boolean
 }
 
-// More query params
-// https://docs.daylight.xyz/reference/get_v1-wallets-address-abilities
-const QUERY_PARAMS = {
-  // The most interesting abilities will be the first
-  sort: "magic",
-  sortDirection: "desc",
-  // The limit needs to be set. It is set to the highest value.
-  limit: "1000",
-  deadline: "all",
-}
-
 export const getDaylightAbilities = async (
   address: string,
   // Amount of times to retry fetching abilities for an address that is not fully synced yet.
   // https://docs.daylight.xyz/reference/retrieve-wallets-abilities
   retries = DEFAULT_RETRIES
 ): Promise<DaylightAbility[]> => {
+  // Learn more at https://docs.daylight.xyz/reference/get_v1-wallets-address-abilities
+  const requestURL = new URL(
+    `${DAYLIGHT_BASE_URL}/wallets/${address}/abilities`
+  )
+  // The most interesting abilities will be the first
+  requestURL.searchParams.set("sort", "magic")
+  requestURL.searchParams.set("sortDirection", "desc")
+  // The limit needs to be set. It is set to the highest value.
+  requestURL.searchParams.set("limit", "1000")
+  requestURL.searchParams.set("deadline", "all")
+
   try {
-    const params = Object.entries(QUERY_PARAMS)
-      .reduce((result, [key, value]) => {
-        return result.concat("&", `${key}=${value}`)
-      }, "")
-      .substring(1)
     const response: AbilitiesResponse = await fetchJson({
-      url: `${DAYLIGHT_BASE_URL}/wallets/${address}/abilities?${params}`,
+      url: requestURL.toString(),
       ...(process.env.DAYLIGHT_API_KEY && {
         headers: {
           Authorization: `Bearer ${process.env.DAYLIGHT_API_KEY}`,


### PR DESCRIPTION
This PR changes the limit for getting abilities. There has been a change in the API. By default, the limit is set to 15.  The number has been increased to the maximum. A parameter responsible for the order in which abilities are taken has also been added. 

At this point, completed abilities are not being fetched. The user has the option to mark the ability as completed in the wallet. This should probably be resolved and streamlined. It is not in the scope of this PR. Probably to be resolved later.

Latest build: [extension-builds-3066](https://github.com/tallyhowallet/extension/suites/11130316814/artifacts/567497892) (as of Wed, 22 Feb 2023 09:59:37 GMT).